### PR TITLE
Feature/obsolete apis

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The main part of Spatial4n is its collection of shapes.  Shapes in Spatial4n hav
 * Compute its lat-lon bounding box.
 * Compute an area.  For some shapes its more of an estimate.
 * Compute if it contains a provided point.
-* Compute the relationship to a lat-lon rectangle. Relationships are: `CONTAINS`, `WITHIN`, `DISJOINT`, `INTERSECTS`.  Note that Spatial4n doesn't have a notion of "touching".
+* Compute the relationship to a lat-lon rectangle. Relationships are: `Contains`, `Within`, `Disjoint`, `Intersects`.  Note that Spatial4n doesn't have a notion of "touching".
 
 Spatial4n has a variety of shapes that operate in Euclidean-space -- i.e. a flat 2D plane.  Most shapes are augmented to support a wrap-around at `X` -180/+180 for compatibility with latitude & longitudes, which is effectively a cylindrical model.  But the real bonus is its circle (i.e. point-radius shape that can operate on a surface-of-a-sphere model.  See below for further info.  The term "geodetic" or "geodesic" or "geo" is used here as synonymous with that model but technically those words have a more broad meaning.
 

--- a/Spatial4n.Core.NTS/Io/Nts/NtsBinaryCodec.cs
+++ b/Spatial4n.Core.NTS/Io/Nts/NtsBinaryCodec.cs
@@ -31,7 +31,7 @@ namespace Spatial4n.Core.IO.Nts
     public class NtsBinaryCodec : BinaryCodec
     {
         protected readonly bool useFloat;//instead of double
-        private const int wkbXDR = 0;
+        //private const int wkbXDR = 0; // Spatial4n: Unused
         public NtsBinaryCodec(NtsSpatialContext ctx, NtsSpatialContextFactory factory)
             : base(ctx, factory)
         {
@@ -59,21 +59,21 @@ namespace Spatial4n.Core.IO.Nts
             ShapeType type = base.TypeForShape(s);
             if (type == 0)
             {
-                type = ShapeType.TYPE_GEOM;//handles everything
+                type = ShapeType.Geometry;//handles everything
             }
             return type;
         }
 
         protected override IShape? ReadShapeByTypeIfSupported(BinaryReader dataInput, ShapeType type)
         {
-            if (type != ShapeType.TYPE_GEOM)
+            if (type != ShapeType.Geometry)
                 return base.ReadShapeByTypeIfSupported(dataInput, type);
             return ReadNtsGeom(dataInput);
         }
 
         protected override bool WriteShapeByTypeIfSupported(BinaryWriter dataOutput, IShape s, ShapeType type)
         {
-            if (type != ShapeType.TYPE_GEOM)
+            if (type != ShapeType.Geometry)
                 return base.WriteShapeByTypeIfSupported(dataOutput, s, type);
             WriteNtsGeom(dataOutput, s);
             return true;

--- a/Spatial4n.Core.NTS/Shapes/Nts/NtsGeometry.cs
+++ b/Spatial4n.Core.NTS/Shapes/Nts/NtsGeometry.cs
@@ -227,7 +227,7 @@ namespace Spatial4n.Core.Shapes.Nts
         public virtual SpatialRelation Relate(IPoint pt)
         {
             if (!BoundingBox.Relate(pt).Intersects())
-                return SpatialRelation.DISJOINT;
+                return SpatialRelation.Disjoint;
             IGeometry ptGeom;
             if (pt is NtsPoint)
                 ptGeom = ((NtsPoint)pt).Geometry;
@@ -239,7 +239,7 @@ namespace Spatial4n.Core.Shapes.Nts
         public virtual SpatialRelation Relate(IRectangle rectangle)
         {
             SpatialRelation bboxR = bbox.Relate(rectangle);
-            if (bboxR == SpatialRelation.WITHIN || bboxR == SpatialRelation.DISJOINT)
+            if (bboxR == SpatialRelation.Within || bboxR == SpatialRelation.Disjoint)
                 return bboxR;
             // FYI, the right answer could still be DISJOINT or WITHIN, but we don't know yet.
             return Relate(ctx.GetGeometryFrom(rectangle));
@@ -248,7 +248,7 @@ namespace Spatial4n.Core.Shapes.Nts
         public virtual SpatialRelation Relate(ICircle circle)
         {
             SpatialRelation bboxR = bbox.Relate(circle);
-            if (bboxR == SpatialRelation.WITHIN || bboxR == SpatialRelation.DISJOINT)
+            if (bboxR == SpatialRelation.Within || bboxR == SpatialRelation.Disjoint)
                 return bboxR;
 
             //Test each point to see how many of them are outside of the circle.
@@ -260,18 +260,18 @@ namespace Spatial4n.Core.Shapes.Nts
             {
                 i++;
                 SpatialRelation sect = circle.Relate(new Impl.Point(coord.X, coord.Y, ctx));
-                if (sect == SpatialRelation.DISJOINT)
+                if (sect == SpatialRelation.Disjoint)
                     outside++;
                 if (i != outside && outside != 0)//short circuit: partially outside, partially inside
-                    return SpatialRelation.INTERSECTS;
+                    return SpatialRelation.Intersects;
             }
             if (i == outside)
             {
-                return (Relate(circle.Center) == SpatialRelation.DISJOINT)
-                    ? SpatialRelation.DISJOINT : SpatialRelation.CONTAINS;
+                return (Relate(circle.Center) == SpatialRelation.Disjoint)
+                    ? SpatialRelation.Disjoint : SpatialRelation.Contains;
             }
             Debug.Assert(outside == 0);
-            return SpatialRelation.WITHIN;
+            return SpatialRelation.Within;
         }
 
         public virtual SpatialRelation Relate(NtsGeometry ntsGeometry)
@@ -286,18 +286,18 @@ namespace Spatial4n.Core.Shapes.Nts
             if (oGeom is GeoAPI.Geometries.IPoint) // TODO: This may not be the correct data type....
             {
                 if (preparedGeometry != null)
-                    return preparedGeometry.Disjoint(oGeom) ? SpatialRelation.DISJOINT : SpatialRelation.CONTAINS;
-                return geom.Disjoint(oGeom) ? SpatialRelation.DISJOINT : SpatialRelation.CONTAINS;
+                    return preparedGeometry.Disjoint(oGeom) ? SpatialRelation.Disjoint : SpatialRelation.Contains;
+                return geom.Disjoint(oGeom) ? SpatialRelation.Disjoint : SpatialRelation.Contains;
             }
             if (preparedGeometry == null)
                 return IntersectionMatrixToSpatialRelation(geom.Relate(oGeom));
             else if (preparedGeometry.Covers(oGeom))
-                return SpatialRelation.CONTAINS;
+                return SpatialRelation.Contains;
             else if (preparedGeometry.CoveredBy(oGeom))
-                return SpatialRelation.WITHIN;
+                return SpatialRelation.Within;
             else if (preparedGeometry.Intersects(oGeom))
-                return SpatialRelation.INTERSECTS;
-            return SpatialRelation.DISJOINT;
+                return SpatialRelation.Intersects;
+            return SpatialRelation.Disjoint;
         }
 
         public static SpatialRelation IntersectionMatrixToSpatialRelation(IntersectionMatrix matrix)
@@ -305,12 +305,12 @@ namespace Spatial4n.Core.Shapes.Nts
             //As indicated in SpatialRelation javadocs, Spatial4j CONTAINS & WITHIN are
             // OGC's COVERS & COVEREDBY
             if (matrix.IsCovers())
-                return SpatialRelation.CONTAINS;
+                return SpatialRelation.Contains;
             else if (matrix.IsCoveredBy())
-                return SpatialRelation.WITHIN;
+                return SpatialRelation.Within;
             else if (matrix.IsDisjoint())
-                return SpatialRelation.DISJOINT;
-            return SpatialRelation.INTERSECTS;
+                return SpatialRelation.Disjoint;
+            return SpatialRelation.Intersects;
         }
 
         public override string ToString()

--- a/Spatial4n.Core.NTS/Shapes/Nts/NtsPoint.cs
+++ b/Spatial4n.Core.NTS/Shapes/Nts/NtsPoint.cs
@@ -70,9 +70,9 @@ namespace Spatial4n.Core.Shapes.Nts
         {
             // ** NOTE ** the overall order of logic is kept consistent here with simple.PointImpl.
             if (IsEmpty || other.IsEmpty)
-                return SpatialRelation.DISJOINT;
+                return SpatialRelation.Disjoint;
             if (other is Spatial4n.Core.Shapes.IPoint)
-                return this.Equals(other) ? SpatialRelation.INTERSECTS : SpatialRelation.DISJOINT;
+                return this.Equals(other) ? SpatialRelation.Intersects : SpatialRelation.Disjoint;
             return other.Relate(this).Transpose();
         }
 

--- a/Spatial4n.Core/Context/SpatialContext.cs
+++ b/Spatial4n.Core/Context/SpatialContext.cs
@@ -60,7 +60,7 @@ namespace Spatial4n.Core.Context
         /// <param name="geo">Establishes geo vs cartesian / Euclidean.</param>
         /// <param name="calculator">Optional; defaults to Haversine or cartesian depending on units.</param>
         /// <param name="worldBounds">Optional; defaults to GEO_WORLDBOUNDS or MAX_WORLDBOUNDS depending on units.</param> 
-        [Obsolete]
+        [Obsolete, System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
         public SpatialContext(bool geo, IDistanceCalculator calculator, IRectangle worldBounds)
             : this(InitFromLegacyConstructor(geo, calculator, worldBounds))
         { }
@@ -76,7 +76,7 @@ namespace Spatial4n.Core.Context
             return factory;
         }
 
-        [Obsolete]
+        [Obsolete, System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
         public SpatialContext(bool geo)
             : this(InitFromLegacyConstructor(geo, null, null))
         { }
@@ -377,7 +377,7 @@ namespace Spatial4n.Core.Context
         /// </summary>
         /// <param name="value">non-null</param>
         /// <returns>non-null</returns>
-        [Obsolete]
+        [Obsolete, System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
         public virtual IShape ReadShape(string value)
         {
             IShape? s = LegacyShapeReadWriterFormat.ReadShapeOrNull(value, this);
@@ -407,7 +407,7 @@ namespace Spatial4n.Core.Context
         /// </summary>
         /// <param name="shape">non-null</param>
         /// <returns>non-null</returns>
-        [Obsolete]
+        [Obsolete, System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
         public virtual string ToString(IShape shape)
         {
             return LegacyShapeReadWriterFormat.WriteShape(shape);

--- a/Spatial4n.Core/Context/SpatialContextFactory.cs
+++ b/Spatial4n.Core/Context/SpatialContextFactory.cs
@@ -234,7 +234,7 @@ namespace Spatial4n.Core.Context
 #pragma warning restore 612, 618
         }
 
-        [Obsolete("Use CreateSpatialContext() instead.")]
+        [Obsolete("Use CreateSpatialContext() instead."), System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
         protected internal virtual SpatialContext NewSpatialContext()
         {
             return CreateSpatialContext();

--- a/Spatial4n.Core/Distance/DistanceUtils.cs
+++ b/Spatial4n.Core/Distance/DistanceUtils.cs
@@ -479,7 +479,7 @@ namespace Spatial4n.Core.Distance
         /// <param name="vec1">The first point</param>
         /// <param name="vec2">The second point</param>
         /// <returns>The squared cartesian distance</returns>
-        [Obsolete]
+        [Obsolete, System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
         public static double DistSquaredCartesian(double[] vec1, double[] vec2)
         {
             double result = 0;

--- a/Spatial4n.Core/Distance/DistanceUtils.cs
+++ b/Spatial4n.Core/Distance/DistanceUtils.cs
@@ -33,44 +33,82 @@ namespace Spatial4n.Core.Distance
     public static class DistanceUtils
     {
         //pre-compute some angles that are commonly used
-        [Obsolete]
-        public static readonly double DEG_45_AS_RADS = Math.PI / 4;
-#pragma warning disable 612, 618
-        [Obsolete]
-        public static readonly double SIN_45_AS_RADS = Math.Sin(DEG_45_AS_RADS);
-#pragma warning restore 612, 618
+        //[Obsolete]
+        //public const double Degrees45AsRadians = Math.PI / 4;
+        //[Obsolete]
+        //public static readonly double Sine45AsRadians = Math.Sin(Degrees45AsRadians);
 
-        public static readonly double DEG_90_AS_RADS = Math.PI / 2;
-        public static readonly double DEG_180_AS_RADS = Math.PI;
+        public const double Degrees90AsRadians = Math.PI / 2;
+        public const double Degrees180AsRadians = Math.PI;
 
-#pragma warning disable 612, 618
-        [Obsolete]
-        public static readonly double DEG_225_AS_RADS = 5 * DEG_45_AS_RADS;
-#pragma warning restore 612, 618
-        [Obsolete]
-        public static readonly double DEG_270_AS_RADS = 3 * DEG_90_AS_RADS;
+        //[Obsolete]
+        //public const double Degrees225AsRadians = 5 * Degrees45AsRadians;
+        //[Obsolete]
+        //public const double Degrees270AsRadians = 3 * Degrees90AsRadians;
 
-        public static readonly double DEGREES_TO_RADIANS = Math.PI / 180;
-        public static readonly double RADIANS_TO_DEGREES = 1 / DEGREES_TO_RADIANS;
+        public const double DegreesToRadians = Math.PI / 180;
+        public const double RadiansToDegrees = 1 / DegreesToRadians;
 
-        public static readonly double KM_TO_MILES = 0.621371192;
-        public static readonly double MILES_TO_KM = 1 / KM_TO_MILES;//1.609
+        public const double KilometersToMiles = 0.621371192;
+        public const double MilesToKilometers = 1 / KilometersToMiles;//1.609
 
         /// <summary>
         /// The International Union of Geodesy and Geophysics says the Earth's mean radius in KM is:
         ///
         /// [1] http://en.wikipedia.org/wiki/Earth_radius
         /// </summary>
-        public static readonly double EARTH_MEAN_RADIUS_KM = 6371.0087714;
-        public static readonly double EARTH_EQUATORIAL_RADIUS_KM = 6378.1370;
+        public const double EarthMeanRadiusKilometers = 6371.0087714;
+        public const double EarthEquatorialRadiusKilometers = 6378.1370;
 
         /// <summary>
-        /// Equivalent to Degrees2Dist(1, EARTH_MEAN_RADIUS_KM)
+        /// Equivalent to Degrees2Dist(1, EarthMeanRadiusKilometers)
         /// </summary>
+        public const double DegreesToKilometers = DegreesToRadians * EarthMeanRadiusKilometers;
+        public const double KilometersToDegrees = 1 / DegreesToKilometers;
+
+        public const double EarthMeanRadiusMiles = EarthMeanRadiusKilometers * KilometersToMiles;
+        public const double EarthEquatorialRadiusMiles = EarthEquatorialRadiusKilometers * KilometersToMiles;
+
+
+        //pre-compute some angles that are commonly used
+        [Obsolete, System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+        public static readonly double DEG_45_AS_RADS = Math.PI / 4;
+        [Obsolete, System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+        public static readonly double SIN_45_AS_RADS = Math.Sin(DEG_45_AS_RADS);
+
+        [Obsolete("Use None instead. This const will be removed in 0.5.0."), System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+        public static readonly double DEG_90_AS_RADS = Math.PI / 2;
+        [Obsolete("Use None instead. This const will be removed in 0.5.0."), System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+        public static readonly double DEG_180_AS_RADS = Math.PI;
+
+        [Obsolete, System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+        public static readonly double DEG_225_AS_RADS = 5 * DEG_45_AS_RADS;
+        [Obsolete, System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+        public static readonly double DEG_270_AS_RADS = 3 * DEG_90_AS_RADS;
+
+        [Obsolete("Use DegreesToRadians instead. This const will be removed in 0.5.0."), System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+        public static readonly double DEGREES_TO_RADIANS = Math.PI / 180;
+        [Obsolete("Use RadiansToDegrees instead. This const will be removed in 0.5.0."), System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+        public static readonly double RADIANS_TO_DEGREES = 1 / DEGREES_TO_RADIANS;
+
+        [Obsolete("Use KilometersToMiles instead. This const will be removed in 0.5.0."), System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+        public static readonly double KM_TO_MILES = 0.621371192;
+        [Obsolete("Use MilesToKilometers instead. This const will be removed in 0.5.0."), System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+        public static readonly double MILES_TO_KM = 1 / KM_TO_MILES;//1.609
+
+        [Obsolete("Use EarthMeanRadiusKilometers instead. This const will be removed in 0.5.0."), System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+        public static readonly double EARTH_MEAN_RADIUS_KM = 6371.0087714;
+        [Obsolete("Use EarthEquatorialRadiusKilometers instead. This const will be removed in 0.5.0."), System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+        public static readonly double EARTH_EQUATORIAL_RADIUS_KM = 6378.1370;
+
+        [Obsolete("Use DegreesToKilometers instead. This const will be removed in 0.5.0."), System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
         public static readonly double DEG_TO_KM = DEGREES_TO_RADIANS * EARTH_MEAN_RADIUS_KM;
+        [Obsolete("Use KilometersToDegrees instead. This const will be removed in 0.5.0."), System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
         public static readonly double KM_TO_DEG = 1 / DEG_TO_KM;
 
+        [Obsolete("Use EarthMeanRadiusMiles instead. This const will be removed in 0.5.0."), System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
         public static readonly double EARTH_MEAN_RADIUS_MI = EARTH_MEAN_RADIUS_KM * KM_TO_MILES;
+        [Obsolete("Use EarthEquatorialRadiusMiles instead. This const will be removed in 0.5.0."), System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
         public static readonly double EARTH_EQUATORIAL_RADIUS_MI = EARTH_EQUATORIAL_RADIUS_KM * KM_TO_MILES;
 
         /// <summary>
@@ -81,7 +119,7 @@ namespace Spatial4n.Core.Distance
         /// <param name="power">The power (2 for cartesian distance, 1 for manhattan, etc.)</param>
         /// <returns>The length. See http://en.wikipedia.org/wiki/Lp_space </returns>
         /// <seealso cref="VectorDistance(double[], double[], double, double)"/>
-        [Obsolete]
+        [Obsolete, System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
         public static double VectorDistance(double[] vec1, double[] vec2, double power)
         {
             //only calc oneOverPower if it's needed
@@ -98,7 +136,7 @@ namespace Spatial4n.Core.Distance
         /// <param name="oneOverPower">If you've precalculated <paramref name="oneOverPower"/> and cached it, 
         /// use this method to save one division operation over <seealso cref="VectorDistance(double[], double[], double)"/>.</param>
         /// <returns>The length.</returns>
-        [Obsolete]
+        [Obsolete, System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
         public static double VectorDistance(double[] vec1, double[] vec2, double power, double oneOverPower)
         {
             double result = 0;
@@ -149,7 +187,7 @@ namespace Spatial4n.Core.Distance
         /// <param name="distance">The distance from the center to the corner</param>
         /// <param name="upperRight">If true, return the coords for the upper right corner, else return the lower left.</param>
         /// <returns>The point, either the upperLeft or the lower right</returns>
-        [Obsolete]
+        [Obsolete, System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
         public static double[] VectorBoxCorner(double[] center, double[] result, double distance, bool upperRight)
         {
             if (result == null || result.Length != center.Length)
@@ -198,38 +236,38 @@ namespace Spatial4n.Core.Distance
                 cosAngDist - sinStartLat * sinLat2);
 
             // normalize lon first
-            if (lon2 > DEG_180_AS_RADS)
+            if (lon2 > Degrees180AsRadians)
             {
-                lon2 = -1.0 * (DEG_180_AS_RADS - (lon2 - DEG_180_AS_RADS));
+                lon2 = -1.0 * (Degrees180AsRadians - (lon2 - Degrees180AsRadians));
             }
-            else if (lon2 < -DEG_180_AS_RADS)
+            else if (lon2 < -Degrees180AsRadians)
             {
-                lon2 = (lon2 + DEG_180_AS_RADS) + DEG_180_AS_RADS;
+                lon2 = (lon2 + Degrees180AsRadians) + Degrees180AsRadians;
             }
 
             // normalize lat - could flip poles
-            if (lat2 > DEG_90_AS_RADS)
+            if (lat2 > Degrees90AsRadians)
             {
-                lat2 = DEG_90_AS_RADS - (lat2 - DEG_90_AS_RADS);
+                lat2 = Degrees90AsRadians - (lat2 - Degrees90AsRadians);
                 if (lon2 < 0)
                 {
-                    lon2 = lon2 + DEG_180_AS_RADS;
+                    lon2 = lon2 + Degrees180AsRadians;
                 }
                 else
                 {
-                    lon2 = lon2 - DEG_180_AS_RADS;
+                    lon2 = lon2 - Degrees180AsRadians;
                 }
             }
-            else if (lat2 < -DEG_90_AS_RADS)
+            else if (lat2 < -Degrees90AsRadians)
             {
-                lat2 = -DEG_90_AS_RADS - (lat2 + DEG_90_AS_RADS);
+                lat2 = -Degrees90AsRadians - (lat2 + Degrees90AsRadians);
                 if (lon2 < 0)
                 {
-                    lon2 = lon2 + DEG_180_AS_RADS;
+                    lon2 = lon2 + Degrees180AsRadians;
                 }
                 else
                 {
-                    lon2 = lon2 - DEG_180_AS_RADS;
+                    lon2 = lon2 - Degrees180AsRadians;
                 }
             }
 
@@ -501,8 +539,8 @@ namespace Spatial4n.Core.Distance
             // crossing 180 since cos(x) = cos(-x)
             double dLon = lon2 - lon1;
 
-            double a = DEG_90_AS_RADS - lat1;
-            double c = DEG_90_AS_RADS - lat2;
+            double a = Degrees90AsRadians - lat1;
+            double c = Degrees90AsRadians - lat2;
             double cosB = (Math.Cos(a) * Math.Cos(c))
                 + (Math.Sin(a) * Math.Sin(c) * Math.Cos(dLon));
 
@@ -587,7 +625,7 @@ namespace Spatial4n.Core.Distance
         /// </summary>
         public static double ToRadians(double degrees)
         {
-            return degrees * DEGREES_TO_RADIANS;
+            return degrees * DegreesToRadians;
         }
 
         /// <summary>
@@ -596,7 +634,7 @@ namespace Spatial4n.Core.Distance
         /// </summary>
         public static double ToDegrees(double radians)
         {
-            return radians * RADIANS_TO_DEGREES;
+            return radians * RadiansToDegrees;
         }
     }
 }

--- a/Spatial4n.Core/Distance/GeodesicSphereDistCalc.cs
+++ b/Spatial4n.Core/Distance/GeodesicSphereDistCalc.cs
@@ -25,11 +25,11 @@ namespace Spatial4n.Core.Distance
     /// A base class for a Distance Calculator that assumes a spherical earth model. 
     /// </summary>
     public abstract class GeodesicSphereDistCalc : AbstractDistanceCalculator
-	{
-		private readonly double radiusDEG = DistanceUtils.ToDegrees(1);//in degrees
+    {
+        private readonly double radiusDEG = DistanceUtils.ToDegrees(1);//in degrees
 
-		public override IPoint PointOnBearing(IPoint from, double distDEG, double bearingDEG, SpatialContext ctx, IPoint? reuse)
-		{
+        public override IPoint PointOnBearing(IPoint from, double distDEG, double bearingDEG, SpatialContext ctx, IPoint? reuse)
+        {
             if (distDEG == 0)
             {
                 if (reuse is null)
@@ -43,78 +43,78 @@ namespace Spatial4n.Core.Distance
                 DistanceUtils.ToRadians(bearingDEG), ctx, reuse);//output result is in radians
             result.Reset(DistanceUtils.ToDegrees(result.X), DistanceUtils.ToDegrees(result.Y));
             return result;
-		}
+        }
 
-		public override IRectangle CalcBoxByDistFromPt(IPoint from, double distDEG, SpatialContext ctx, IRectangle? reuse)
-		{
+        public override IRectangle CalcBoxByDistFromPt(IPoint from, double distDEG, SpatialContext ctx, IRectangle? reuse)
+        {
             return DistanceUtils.CalcBoxByDistFromPtDEG(from.Y, from.X, distDEG, ctx, reuse);
-		}
+        }
 
-		public override double CalcBoxByDistFromPt_yHorizAxisDEG(IPoint from, double distDEG, SpatialContext ctx)
-		{
-			return DistanceUtils.CalcBoxByDistFromPt_latHorizAxisDEG(from.Y, from.X, distDEG);
-		}
+        public override double CalcBoxByDistFromPt_yHorizAxisDEG(IPoint from, double distDEG, SpatialContext ctx)
+        {
+            return DistanceUtils.CalcBoxByDistFromPt_latHorizAxisDEG(from.Y, from.X, distDEG);
+        }
 
-		public override double Area(IRectangle rect)
-		{
-			//From http://mathforum.org/library/drmath/view/63767.html
-			double lat1 = DistanceUtils.ToRadians(rect.MinY);
-			double lat2 = DistanceUtils.ToRadians(rect.MaxY);
-			return Math.PI / 180 * radiusDEG * radiusDEG *
-					Math.Abs(Math.Sin(lat1) - Math.Sin(lat2)) *
-					rect.Width;
-		}
+        public override double Area(IRectangle rect)
+        {
+            //From http://mathforum.org/library/drmath/view/63767.html
+            double lat1 = DistanceUtils.ToRadians(rect.MinY);
+            double lat2 = DistanceUtils.ToRadians(rect.MaxY);
+            return Math.PI / 180 * radiusDEG * radiusDEG *
+                    Math.Abs(Math.Sin(lat1) - Math.Sin(lat2)) *
+                    rect.Width;
+        }
 
-		public override double Area(ICircle circle)
-		{
-			//formula is a simplified case of area(rect).
-			double lat = DistanceUtils.ToRadians(90 - circle.Radius);
-			return 2 * Math.PI * radiusDEG * radiusDEG * (1 - Math.Sin(lat));
-		}
+        public override double Area(ICircle circle)
+        {
+            //formula is a simplified case of area(rect).
+            double lat = DistanceUtils.ToRadians(90 - circle.Radius);
+            return 2 * Math.PI * radiusDEG * radiusDEG * (1 - Math.Sin(lat));
+        }
 
-		public override bool Equals(object o)
-		{
-			if (o == null) return false;
-			return GetType() == o.GetType();
-		}
+        public override bool Equals(object o)
+        {
+            if (o == null) return false;
+            return GetType() == o.GetType();
+        }
 
-		public override int GetHashCode()
-		{
-			return GetType().GetHashCode();
-		}
+        public override int GetHashCode()
+        {
+            return GetType().GetHashCode();
+        }
 
-		public override double Distance(IPoint @from, double toX, double toY)
-		{
-			return DistanceUtils.ToDegrees(DistanceLatLonRAD(DistanceUtils.ToRadians(from.Y),
-				DistanceUtils.ToRadians(from.X), DistanceUtils.ToRadians(toY), DistanceUtils.ToRadians(toX)));
-		}
+        public override double Distance(IPoint @from, double toX, double toY)
+        {
+            return DistanceUtils.ToDegrees(DistanceLatLonRAD(DistanceUtils.ToRadians(from.Y),
+                DistanceUtils.ToRadians(from.X), DistanceUtils.ToRadians(toY), DistanceUtils.ToRadians(toX)));
+        }
 
-		protected abstract double DistanceLatLonRAD(double lat1, double lon1, double lat2, double lon2);
+        protected abstract double DistanceLatLonRAD(double lat1, double lon1, double lat2, double lon2);
 
-		public class Haversine : GeodesicSphereDistCalc
-		{
+        public class Haversine : GeodesicSphereDistCalc
+        {
 
-			protected override double DistanceLatLonRAD(double lat1, double lon1, double lat2, double lon2)
-			{
-				return DistanceUtils.DistHaversineRAD(lat1, lon1, lat2, lon2);
-			}
-		}
+            protected override double DistanceLatLonRAD(double lat1, double lon1, double lat2, double lon2)
+            {
+                return DistanceUtils.DistHaversineRAD(lat1, lon1, lat2, lon2);
+            }
+        }
 
-		public class LawOfCosines : GeodesicSphereDistCalc
-		{
-			protected override double DistanceLatLonRAD(double lat1, double lon1, double lat2, double lon2)
-			{
-				return DistanceUtils.DistLawOfCosinesRAD(lat1, lon1, lat2, lon2);
-			}
+        public class LawOfCosines : GeodesicSphereDistCalc
+        {
+            protected override double DistanceLatLonRAD(double lat1, double lon1, double lat2, double lon2)
+            {
+                return DistanceUtils.DistLawOfCosinesRAD(lat1, lon1, lat2, lon2);
+            }
 
-		}
+        }
 
-		public class Vincenty : GeodesicSphereDistCalc
-		{
-			protected override double DistanceLatLonRAD(double lat1, double lon1, double lat2, double lon2)
-			{
-				return DistanceUtils.DistVincentyRAD(lat1, lon1, lat2, lon2);
-			}
-		}
-	}
+        public class Vincenty : GeodesicSphereDistCalc
+        {
+            protected override double DistanceLatLonRAD(double lat1, double lon1, double lat2, double lon2)
+            {
+                return DistanceUtils.DistVincentyRAD(lat1, lon1, lat2, lon2);
+            }
+        }
+    }
 }

--- a/Spatial4n.Core/Exceptions/InvalidShapeException.cs
+++ b/Spatial4n.Core/Exceptions/InvalidShapeException.cs
@@ -28,7 +28,7 @@ namespace Spatial4n.Core.Exceptions
     /// parsing exceptions; that's usually <see cref="ParseException"/>.
     /// </summary>
 #if FEATURE_SERIALIZABLE
-	[Serializable]
+    [Serializable]
 #endif
     public class InvalidShapeException : RuntimeException
     {

--- a/Spatial4n.Core/Exceptions/RuntimeException.cs
+++ b/Spatial4n.Core/Exceptions/RuntimeException.cs
@@ -11,7 +11,7 @@ namespace Spatial4n.Core.Exceptions
     /// <see cref="Exception"/>.
     /// </summary>
 #if FEATURE_SERIALIZABLE
-	[Serializable]
+    [Serializable]
 #endif
     public class RuntimeException : Exception
     {

--- a/Spatial4n.Core/Io/BinaryCodec.cs
+++ b/Spatial4n.Core/Io/BinaryCodec.cs
@@ -20,6 +20,7 @@ using Spatial4n.Core.Exceptions;
 using Spatial4n.Core.Shapes;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 
 namespace Spatial4n.Core.IO
@@ -35,12 +36,23 @@ namespace Spatial4n.Core.IO
     public class BinaryCodec
     {
         //type 0; reserved for unkonwn/generic; see readCollection
+        [SuppressMessage("Design", "CA1027:Mark enums with FlagsAttribute", Justification = "Not a flags enum")]
         protected enum ShapeType : byte
         {
+            Point = 1,
+            [Obsolete("Use Point instead. This const will be removed in 0.5.0."), System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
             TYPE_POINT = 1,
+            Rectangle = 2,
+            [Obsolete("Use Point instead. This const will be removed in 0.5.0."), System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
             TYPE_RECT = 2,
+            Circle = 3,
+            [Obsolete("Use Point instead. This const will be removed in 0.5.0."), System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
             TYPE_CIRCLE = 3,
+            Collection = 4,
+            [Obsolete("Use Point instead. This const will be removed in 0.5.0."), System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
             TYPE_COLL = 4,
+            Geometry = 5,
+            [Obsolete("Use Point instead. This const will be removed in 0.5.0."), System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
             TYPE_GEOM = 5
         }
 
@@ -49,7 +61,8 @@ namespace Spatial4n.Core.IO
 
         protected readonly SpatialContext ctx;
 
-        //This constructor is mandated by SpatialContextFactory
+
+        [SuppressMessage("Style", "IDE0060:Remove unused parameter", Justification = "This constructor is mandated by SpatialContextFactory")]
         public BinaryCodec(SpatialContext ctx, SpatialContextFactory factory)
         {
             this.ctx = ctx;
@@ -75,10 +88,10 @@ namespace Spatial4n.Core.IO
         {
             switch (type)
             {
-                case ShapeType.TYPE_POINT: return ReadPoint(dataInput);
-                case ShapeType.TYPE_RECT: return ReadRect(dataInput);
-                case ShapeType.TYPE_CIRCLE: return ReadCircle(dataInput);
-                case ShapeType.TYPE_COLL: return ReadCollection(dataInput);
+                case ShapeType.Point: return ReadPoint(dataInput);
+                case ShapeType.Rectangle: return ReadRect(dataInput);
+                case ShapeType.Circle: return ReadCircle(dataInput);
+                case ShapeType.Collection: return ReadCollection(dataInput);
                 default: return null;
             }
         }
@@ -98,10 +111,10 @@ namespace Spatial4n.Core.IO
         {
             switch (type)
             {
-                case ShapeType.TYPE_POINT: WritePoint(dataOutput, (IPoint)s); break;
-                case ShapeType.TYPE_RECT: WriteRect(dataOutput, (IRectangle)s); break;
-                case ShapeType.TYPE_CIRCLE: WriteCircle(dataOutput, (ICircle)s); break;
-                case ShapeType.TYPE_COLL: WriteCollection(dataOutput, (ShapeCollection)s); break;
+                case ShapeType.Point: WritePoint(dataOutput, (IPoint)s); break;
+                case ShapeType.Rectangle: WriteRect(dataOutput, (IRectangle)s); break;
+                case ShapeType.Circle: WriteCircle(dataOutput, (ICircle)s); break;
+                case ShapeType.Collection: WriteCollection(dataOutput, (ShapeCollection)s); break;
                 default:
                     return false;
             }
@@ -112,19 +125,19 @@ namespace Spatial4n.Core.IO
         {
             if (s is IPoint)
             {
-                return ShapeType.TYPE_POINT;
+                return ShapeType.Point;
             }
             else if (s is IRectangle)
             {
-                return ShapeType.TYPE_RECT;
+                return ShapeType.Rectangle;
             }
             else if (s is ICircle)
             {
-                return ShapeType.TYPE_CIRCLE;
+                return ShapeType.Circle;
             }
             else if (s is ShapeCollection)
             {
-                return ShapeType.TYPE_COLL;
+                return ShapeType.Collection;
             }
             else
             {

--- a/Spatial4n.Core/Io/ParseUtils.cs
+++ b/Spatial4n.Core/Io/ParseUtils.cs
@@ -29,7 +29,7 @@ namespace Spatial4n.Core.IO
     /// Lucene, LUCENE-773</a>, which in turn came from "LocalLucene".
     /// </para>
     /// </summary>
-    [Obsolete("Not useful; see https://github.com/spatial4j/spatial4j/issues/19")]
+    [Obsolete("Not useful; see https://github.com/spatial4j/spatial4j/issues/19"), System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
     public static class ParseUtils
     {
         /// <summary>

--- a/Spatial4n.Core/Io/ParseUtils.cs
+++ b/Spatial4n.Core/Io/ParseUtils.cs
@@ -151,15 +151,15 @@ namespace Spatial4n.Core.IO
         }
 
         /// <summary>
-		/// Extract (by calling <see cref="ParsePoint(string[], string, int)"/> and validate the latitude and longitude contained
-		/// in the string by making sure the latitude is between 90 &amp; -90 and longitude is between -180 and 180.<p/>
-		/// The latitude is assumed to be the first part of the string and the longitude the second part.
-		/// </summary>
-		/// <param name="latLonStr">The string to parse.  Latitude is the first value, longitude is the second.</param>
-		/// <returns>The lat long</returns>
+        /// Extract (by calling <see cref="ParsePoint(string[], string, int)"/> and validate the latitude and longitude contained
+        /// in the string by making sure the latitude is between 90 &amp; -90 and longitude is between -180 and 180.<p/>
+        /// The latitude is assumed to be the first part of the string and the longitude the second part.
+        /// </summary>
+        /// <param name="latLonStr">The string to parse.  Latitude is the first value, longitude is the second.</param>
+        /// <returns>The lat long</returns>
         /// <exception cref="InvalidShapeException">if there was an error parsing</exception>
         /// <exception cref="ArgumentNullException"><paramref name="latLonStr"/> is <c>null</c>.</exception>
-		public static double[] ParseLatitudeLongitude(string latLonStr)
+        public static double[] ParseLatitudeLongitude(string latLonStr)
         {
             return ParseLatitudeLongitude(null, latLonStr);
         }

--- a/Spatial4n.Core/Shapes/Impl/BufferedLine.cs
+++ b/Spatial4n.Core/Shapes/Impl/BufferedLine.cs
@@ -185,7 +185,7 @@ namespace Spatial4n.Core.Shapes.Impl
         public virtual SpatialRelation Relate(IShape other)
         {
             if (other is IPoint)
-                return Contains((IPoint)other) ? SpatialRelation.CONTAINS : SpatialRelation.DISJOINT;
+                return Contains((IPoint)other) ? SpatialRelation.Contains : SpatialRelation.Disjoint;
             if (other is IRectangle)
                 return Relate((IRectangle)other);
             throw new NotSupportedException();
@@ -195,21 +195,21 @@ namespace Spatial4n.Core.Shapes.Impl
         {
             //Check BBox for disjoint & within.
             SpatialRelation bboxR = bbox.Relate(r);
-            if (bboxR == SpatialRelation.DISJOINT || bboxR == SpatialRelation.WITHIN)
+            if (bboxR == SpatialRelation.Disjoint || bboxR == SpatialRelation.Within)
                 return bboxR;
             //Either CONTAINS, INTERSECTS, or DISJOINT
 
             IPoint scratch = new Point(0, 0, null);
             IPoint prC = r.Center;
             SpatialRelation result = linePrimary.Relate(r, prC, scratch);
-            if (result == SpatialRelation.DISJOINT)
-                return SpatialRelation.DISJOINT;
+            if (result == SpatialRelation.Disjoint)
+                return SpatialRelation.Disjoint;
             SpatialRelation resultOpp = linePerp.Relate(r, prC, scratch);
-            if (resultOpp == SpatialRelation.DISJOINT)
-                return SpatialRelation.DISJOINT;
+            if (resultOpp == SpatialRelation.Disjoint)
+                return SpatialRelation.Disjoint;
             if (result == resultOpp)//either CONTAINS or INTERSECTS
                 return result;
-            return SpatialRelation.INTERSECTS;
+            return SpatialRelation.Intersects;
         }
 
         public virtual bool Contains(IPoint p)

--- a/Spatial4n.Core/Shapes/Impl/CircleImpl.cs
+++ b/Spatial4n.Core/Shapes/Impl/CircleImpl.cs
@@ -97,7 +97,7 @@ namespace Spatial4n.Core.Shapes.Impl
         {
             //This shortcut was problematic in testing due to distinctions of CONTAINS/WITHIN for no-area shapes (lines, points).
             //    if (distance == 0) {
-            //      return point.relate(other,ctx).intersects() ? SpatialRelation.WITHIN : SpatialRelation.DISJOINT;
+            //      return point.relate(other,ctx).intersects() ? SpatialRelation.Within : SpatialRelation.Disjoint;
             //    }
 
             var other1 = other as IPoint;
@@ -121,7 +121,7 @@ namespace Spatial4n.Core.Shapes.Impl
 
         public virtual SpatialRelation Relate(IPoint point)
         {
-            return Contains(point.X, point.Y) ? SpatialRelation.CONTAINS : SpatialRelation.DISJOINT;
+            return Contains(point.X, point.Y) ? SpatialRelation.Contains : SpatialRelation.Disjoint;
         }
 
         public virtual SpatialRelation Relate(IRectangle r)
@@ -130,10 +130,10 @@ namespace Spatial4n.Core.Shapes.Impl
 
             //--We start by leveraging the fact we have a calculated bbox that is "cheaper" than use of DistanceCalculator.
             SpatialRelation bboxSect = enclosingBox.Relate(r);
-            if (bboxSect == SpatialRelation.DISJOINT || bboxSect == SpatialRelation.WITHIN)
+            if (bboxSect == SpatialRelation.Disjoint || bboxSect == SpatialRelation.Within)
                 return bboxSect;
-            if (bboxSect == SpatialRelation.CONTAINS && enclosingBox.Equals(r)) //nasty identity edge-case
-                return SpatialRelation.WITHIN;
+            if (bboxSect == SpatialRelation.Contains && enclosingBox.Equals(r)) //nasty identity edge-case
+                return SpatialRelation.Within;
             //bboxSect is INTERSECTS or CONTAINS
             //The result can be DISJOINT, CONTAINS, or INTERSECTS (not WITHIN)
 
@@ -143,9 +143,9 @@ namespace Spatial4n.Core.Shapes.Impl
         protected virtual SpatialRelation RelateRectanglePhase2(IRectangle r, SpatialRelation bboxSect)
         {
             /*
-			 !! DOES NOT WORK WITH GEO CROSSING DATELINE OR WORLD-WRAP.
-			 TODO upgrade to handle crossing dateline, but not world-wrap; use some x-shifting code from RectangleImpl.
-			 */
+             !! DOES NOT WORK WITH GEO CROSSING DATELINE OR WORLD-WRAP.
+             TODO upgrade to handle crossing dateline, but not world-wrap; use some x-shifting code from RectangleImpl.
+             */
 
             //At this point, the only thing we are certain of is that circle is *NOT* WITHIN r, since the bounding box of a
             // circle MUST be within r for the circle to be within r.
@@ -192,20 +192,20 @@ namespace Spatial4n.Core.Shapes.Impl
             if (xAxis != closestX && yAxis != closestY)
             {
                 if (!Contains(closestX, closestY))
-                    return SpatialRelation.DISJOINT;
+                    return SpatialRelation.Disjoint;
             } // else CAN'T be disjoint if spans axis because earlier bbox check ruled that out
 
             //Now, we know it's *NOT* DISJOINT and it's *NOT* WITHIN either.
             // Does circle CONTAINS r or simply intersect it?
 
             //If circle contains r, then its bbox MUST also CONTAIN r.
-            if (bboxSect != SpatialRelation.CONTAINS)
-                return SpatialRelation.INTERSECTS;
+            if (bboxSect != SpatialRelation.Contains)
+                return SpatialRelation.Intersects;
 
             //If the farthest point of r away from the center of the circle is contained, then all of r is
             // contained.
             if (!Contains(farthestX, farthestY))
-                return SpatialRelation.INTERSECTS;
+                return SpatialRelation.Intersects;
 
             //geodetic detection of farthest Y when rect crosses x axis can't be reliably determined, so
             // check other corner too, which might actually be farthest
@@ -215,11 +215,11 @@ namespace Spatial4n.Core.Shapes.Impl
                 {//r crosses north to south over x axis (confusing)
                     double otherY = (farthestY == r.MaxY ? r.MinY : r.MaxY);
                     if (!Contains(farthestX, otherY))
-                        return SpatialRelation.INTERSECTS;
+                        return SpatialRelation.Intersects;
                 }
             }
 
-            return SpatialRelation.CONTAINS;
+            return SpatialRelation.Contains;
         }
 
         /// <summary>
@@ -237,13 +237,13 @@ namespace Spatial4n.Core.Shapes.Impl
             double crossDist = ctx.DistCalc.Distance(point, circle.Center);
             double aDist = radiusDEG, bDist = circle.Radius;
             if (crossDist > aDist + bDist)
-                return SpatialRelation.DISJOINT;
+                return SpatialRelation.Disjoint;
             if (crossDist < aDist && crossDist + bDist <= aDist)
-                return SpatialRelation.CONTAINS;
+                return SpatialRelation.Contains;
             if (crossDist < bDist && crossDist + aDist <= bDist)
-                return SpatialRelation.WITHIN;
+                return SpatialRelation.Within;
 
-            return SpatialRelation.INTERSECTS;
+            return SpatialRelation.Intersects;
         }
 
         public override string ToString()

--- a/Spatial4n.Core/Shapes/Impl/GeoCircle.cs
+++ b/Spatial4n.Core/Shapes/Impl/GeoCircle.cs
@@ -101,193 +101,193 @@ namespace Spatial4n.Core.Shapes.Impl
         /// Called after bounding box is intersected.
         /// </summary>
         /// <param name="r"></param>
-        /// <param name="bboxSect"><see cref="SpatialRelation.INTERSECTS"/> or <see cref="SpatialRelation.CONTAINS"/> from enclosingBox's intersection</param>
-        /// <returns><see cref="SpatialRelation.DISJOINT"/>, <see cref="SpatialRelation.CONTAINS"/>, or 
-        /// <see cref="SpatialRelation.INTERSECTS"/> (not <see cref="SpatialRelation.WITHIN"/>)</returns>
+        /// <param name="bboxSect"><see cref="SpatialRelation.Intersects"/> or <see cref="SpatialRelation.Contains"/> from enclosingBox's intersection</param>
+        /// <returns><see cref="SpatialRelation.Disjoint"/>, <see cref="SpatialRelation.Contains"/>, or 
+        /// <see cref="SpatialRelation.Intersects"/> (not <see cref="SpatialRelation.Within"/>)</returns>
         protected override SpatialRelation RelateRectanglePhase2(IRectangle r, SpatialRelation bboxSect)
         {
-			if (inverseCircle != null)
-			{
-				return inverseCircle.Relate(r).Inverse();
-			}
+            if (inverseCircle != null)
+            {
+                return inverseCircle.Relate(r).Inverse();
+            }
 
-			//if a pole is wrapped, we have a separate algorithm
-			if (enclosingBox.Width == 360)
-			{
-				return RelateRectangleCircleWrapsPole(r, ctx);
-			}
+            //if a pole is wrapped, we have a separate algorithm
+            if (enclosingBox.Width == 360)
+            {
+                return RelateRectangleCircleWrapsPole(r, ctx);
+            }
 
-			//This is an optimization path for when there are no dateline or pole issues.
-			if (!enclosingBox.CrossesDateLine && !r.CrossesDateLine)
-			{
-				return base.RelateRectanglePhase2(r, bboxSect);
-			}
+            //This is an optimization path for when there are no dateline or pole issues.
+            if (!enclosingBox.CrossesDateLine && !r.CrossesDateLine)
+            {
+                return base.RelateRectanglePhase2(r, bboxSect);
+            }
 
             //Rectangle wraps around the world longitudinally creating a solid band; there are no corners to test intersection
             if (r.Width == 360)
             {
-                return SpatialRelation.INTERSECTS;
+                return SpatialRelation.Intersects;
             }
 
             //do quick check to see if all corners are within this circle for CONTAINS
             int cornersIntersect = NumCornersIntersect(r);
-			if (cornersIntersect == 4)
-			{
-				//ensure r's x axis is within c's.  If it doesn't, r sneaks around the globe to touch the other side (intersect).
-				SpatialRelation xIntersect = r.RelateXRange(enclosingBox.MinX, enclosingBox.MaxX);
-				if (xIntersect == SpatialRelation.WITHIN)
-					return SpatialRelation.CONTAINS;
-				return SpatialRelation.INTERSECTS;
-			}
+            if (cornersIntersect == 4)
+            {
+                //ensure r's x axis is within c's.  If it doesn't, r sneaks around the globe to touch the other side (intersect).
+                SpatialRelation xIntersect = r.RelateXRange(enclosingBox.MinX, enclosingBox.MaxX);
+                if (xIntersect == SpatialRelation.Within)
+                    return SpatialRelation.Contains;
+                return SpatialRelation.Intersects;
+            }
 
-			//INTERSECT or DISJOINT ?
-			if (cornersIntersect > 0)
-				return SpatialRelation.INTERSECTS;
+            //INTERSECT or DISJOINT ?
+            if (cornersIntersect > 0)
+                return SpatialRelation.Intersects;
 
-			//Now we check if one of the axis of the circle intersect with r.  If so we have
-			// intersection.
+            //Now we check if one of the axis of the circle intersect with r.  If so we have
+            // intersection.
 
-			/* x axis intersects  */
-			if (r.RelateYRange(YAxis, YAxis).Intersects() // at y vertical
-				  && r.RelateXRange(enclosingBox.MinX, enclosingBox.MaxX).Intersects())
-				return SpatialRelation.INTERSECTS;
+            /* x axis intersects  */
+            if (r.RelateYRange(YAxis, YAxis).Intersects() // at y vertical
+                  && r.RelateXRange(enclosingBox.MinX, enclosingBox.MaxX).Intersects())
+                return SpatialRelation.Intersects;
 
-			/* y axis intersects */
-			if (r.RelateXRange(XAxis, XAxis).Intersects())
-			{ // at x horizontal
-				double yTop = Center.Y + radiusDEG;
-				Debug.Assert(yTop <= 90);
-				double yBot = Center.Y - radiusDEG;
-				Debug.Assert(yBot >= -90);
-				if (r.RelateYRange(yBot, yTop).Intersects())//back bottom
-					return SpatialRelation.INTERSECTS;
-			}
+            /* y axis intersects */
+            if (r.RelateXRange(XAxis, XAxis).Intersects())
+            { // at x horizontal
+                double yTop = Center.Y + radiusDEG;
+                Debug.Assert(yTop <= 90);
+                double yBot = Center.Y - radiusDEG;
+                Debug.Assert(yBot >= -90);
+                if (r.RelateYRange(yBot, yTop).Intersects())//back bottom
+                    return SpatialRelation.Intersects;
+            }
 
-			return SpatialRelation.DISJOINT;
-		}
+            return SpatialRelation.Disjoint;
+        }
 
-		private SpatialRelation RelateRectangleCircleWrapsPole(IRectangle r, SpatialContext ctx)
-		{
-			//This method handles the case where the circle wraps ONE pole, but not both.  For both,
-			// there is the inverseCircle case handled before now.  The only exception is for the case where
-			// the circle covers the entire globe, and we'll check that first.
-			if (radiusDEG == 180)//whole globe
-				return SpatialRelation.CONTAINS;
+        private SpatialRelation RelateRectangleCircleWrapsPole(IRectangle r, SpatialContext ctx)
+        {
+            //This method handles the case where the circle wraps ONE pole, but not both.  For both,
+            // there is the inverseCircle case handled before now.  The only exception is for the case where
+            // the circle covers the entire globe, and we'll check that first.
+            if (radiusDEG == 180)//whole globe
+                return SpatialRelation.Contains;
 
-			//Check if r is within the pole wrap region:
-			double yTop = Center.Y + radiusDEG;
-			if (yTop > 90)
-			{
-				double yTopOverlap = yTop - 90;
-				Debug.Assert(yTopOverlap <= 90, "yTopOverlap: " + yTopOverlap);
-				if (r.MinY >= 90 - yTopOverlap)
-					return SpatialRelation.CONTAINS;
-			}
-			else
-			{
-				double yBot = point.Y - radiusDEG;
-				if (yBot < -90)
-				{
-					double yBotOverlap = -90 - yBot;
-					Debug.Assert(yBotOverlap <= 90);
-					if (r.MaxY <= -90 + yBotOverlap)
-						return SpatialRelation.CONTAINS;
-				}
-				else
-				{
-					//This point is probably not reachable ??
-					Debug.Assert(yTop == 90 || yBot == -90);//we simply touch a pole
-					//continue
-				}
-			}
+            //Check if r is within the pole wrap region:
+            double yTop = Center.Y + radiusDEG;
+            if (yTop > 90)
+            {
+                double yTopOverlap = yTop - 90;
+                Debug.Assert(yTopOverlap <= 90, "yTopOverlap: " + yTopOverlap);
+                if (r.MinY >= 90 - yTopOverlap)
+                    return SpatialRelation.Contains;
+            }
+            else
+            {
+                double yBot = point.Y - radiusDEG;
+                if (yBot < -90)
+                {
+                    double yBotOverlap = -90 - yBot;
+                    Debug.Assert(yBotOverlap <= 90);
+                    if (r.MaxY <= -90 + yBotOverlap)
+                        return SpatialRelation.Contains;
+                }
+                else
+                {
+                    //This point is probably not reachable ??
+                    Debug.Assert(yTop == 90 || yBot == -90);//we simply touch a pole
+                    //continue
+                }
+            }
 
-			//If there are no corners to check intersection because r wraps completely...
-			if (r.Width == 360)
-				return SpatialRelation.INTERSECTS;
+            //If there are no corners to check intersection because r wraps completely...
+            if (r.Width == 360)
+                return SpatialRelation.Intersects;
 
-			//Check corners:
-			int cornersIntersect = NumCornersIntersect(r);
-			// (It might be possible to reduce contains() calls within nCI() to exactly two, but this intersection
-			//  code is complicated enough as it is.)
+            //Check corners:
+            int cornersIntersect = NumCornersIntersect(r);
+            // (It might be possible to reduce contains() calls within nCI() to exactly two, but this intersection
+            //  code is complicated enough as it is.)
             double frontX = Center.X;
-			if (cornersIntersect == 4)
-			{//all
+            if (cornersIntersect == 4)
+            {//all
                 double backX = frontX <= 0 ? frontX + 180 : frontX - 180;
                 if (r.RelateXRange(backX, backX).Intersects())
-					return SpatialRelation.INTERSECTS;
-				else
-					return SpatialRelation.CONTAINS;
-			}
-			else if (cornersIntersect == 0)
-			{//none
-				if (r.RelateXRange(frontX, frontX).Intersects())
-					return SpatialRelation.INTERSECTS;
-				else
-					return SpatialRelation.DISJOINT;
-			}
-			else//partial
-				return SpatialRelation.INTERSECTS;
-		}
+                    return SpatialRelation.Intersects;
+                else
+                    return SpatialRelation.Contains;
+            }
+            else if (cornersIntersect == 0)
+            {//none
+                if (r.RelateXRange(frontX, frontX).Intersects())
+                    return SpatialRelation.Intersects;
+                else
+                    return SpatialRelation.Disjoint;
+            }
+            else//partial
+                return SpatialRelation.Intersects;
+        }
 
         /// <summary>
         /// Returns either 0 for none, 1 for some, or 4 for all.
         /// </summary>
         private int NumCornersIntersect(IRectangle r)
-		{
-			//We play some logic games to avoid calling contains() which can be expensive.
-			// for partial, we exit early with 1 and ignore bool.
-			bool b = (Contains(r.MinX, r.MinY));
-			if (Contains(r.MinX, r.MaxY))
-			{
-				if (!b)
-					return 1;//partial
-			}
-			else
-			{
-				if (b)
-					return 1;//partial
-			}
-			if (Contains(r.MaxX, r.MinY))
-			{
-				if (!b)
-					return 1;//partial
-			}
-			else
-			{
-				if (b)
-					return 1;//partial
-			}
-			if (Contains(r.MaxX, r.MaxY))
-			{
-				if (!b)
-					return 1;//partial
-			}
-			else
-			{
-				if (b)
-					return 1;//partial
-			}
-			return b ? 4 : 0;
-		}
+        {
+            //We play some logic games to avoid calling contains() which can be expensive.
+            // for partial, we exit early with 1 and ignore bool.
+            bool b = (Contains(r.MinX, r.MinY));
+            if (Contains(r.MinX, r.MaxY))
+            {
+                if (!b)
+                    return 1;//partial
+            }
+            else
+            {
+                if (b)
+                    return 1;//partial
+            }
+            if (Contains(r.MaxX, r.MinY))
+            {
+                if (!b)
+                    return 1;//partial
+            }
+            else
+            {
+                if (b)
+                    return 1;//partial
+            }
+            if (Contains(r.MaxX, r.MaxY))
+            {
+                if (!b)
+                    return 1;//partial
+            }
+            else
+            {
+                if (b)
+                    return 1;//partial
+            }
+            return b ? 4 : 0;
+        }
 
-		public override string ToString()
-		{
+        public override string ToString()
+        {
             double distKm = DistanceUtils.Degrees2Dist(radiusDEG, DistanceUtils.EARTH_MEAN_RADIUS_KM);
-			string dStr = string.Format("{0:0.0}\u00B0 {1:0.00}km", radiusDEG, distKm);
-			return "Circle(" + point + ", d=" + dStr + ')';
-		}
+            string dStr = string.Format("{0:0.0}\u00B0 {1:0.00}km", radiusDEG, distKm);
+            return "Circle(" + point + ", d=" + dStr + ')';
+        }
 
-		private static double Ulp(double value)
-		{
-			if (double.IsNaN(value)) return double.NaN;
-			if (double.IsInfinity(value)) return double.PositiveInfinity;
-			if (value == +0.0d || value == -0.0d) return double.MinValue;
-			if (value == double.MaxValue) return Math.Pow(2, 971);
+        private static double Ulp(double value)
+        {
+            if (double.IsNaN(value)) return double.NaN;
+            if (double.IsInfinity(value)) return double.PositiveInfinity;
+            if (value == +0.0d || value == -0.0d) return double.MinValue;
+            if (value == double.MaxValue) return Math.Pow(2, 971);
 
 
-			long bits = BitConverter.DoubleToInt64Bits(value);
-			double nextValue = BitConverter.Int64BitsToDouble(bits + 1);
-			return nextValue - value;
-		}
-	}
+            long bits = BitConverter.DoubleToInt64Bits(value);
+            double nextValue = BitConverter.Int64BitsToDouble(bits + 1);
+            return nextValue - value;
+        }
+    }
 }

--- a/Spatial4n.Core/Shapes/Impl/GeoCircle.cs
+++ b/Spatial4n.Core/Shapes/Impl/GeoCircle.cs
@@ -272,7 +272,7 @@ namespace Spatial4n.Core.Shapes.Impl
 
         public override string ToString()
         {
-            double distKm = DistanceUtils.Degrees2Dist(radiusDEG, DistanceUtils.EARTH_MEAN_RADIUS_KM);
+            double distKm = DistanceUtils.Degrees2Dist(radiusDEG, DistanceUtils.EarthMeanRadiusKilometers);
             string dStr = string.Format("{0:0.0}\u00B0 {1:0.00}km", radiusDEG, distKm);
             return "Circle(" + point + ", d=" + dStr + ')';
         }

--- a/Spatial4n.Core/Shapes/Impl/InfBufLine.cs
+++ b/Spatial4n.Core/Shapes/Impl/InfBufLine.cs
@@ -74,14 +74,14 @@ namespace Spatial4n.Core.Shapes.Impl
                 CornerByQuadrant(r, cQuad, farthestP);
                 bool farthestContains = Contains(farthestP);
                 if (farthestContains)
-                    return SpatialRelation.CONTAINS;
-                return SpatialRelation.INTERSECTS;
+                    return SpatialRelation.Contains;
+                return SpatialRelation.Intersects;
             }
             else
             {// not nearestContains
                 if (Quadrant(nearestP) == cQuad)
-                    return SpatialRelation.DISJOINT;//out of buffer on same side as center
-                return SpatialRelation.INTERSECTS;//nearest & farthest points straddle the line
+                    return SpatialRelation.Disjoint;//out of buffer on same side as center
+                return SpatialRelation.Intersects;//nearest & farthest points straddle the line
             }
         }
 

--- a/Spatial4n.Core/Shapes/Impl/PointImpl.cs
+++ b/Spatial4n.Core/Shapes/Impl/PointImpl.cs
@@ -72,9 +72,9 @@ namespace Spatial4n.Core.Shapes.Impl
         public virtual SpatialRelation Relate(IShape other)
         {
             if (IsEmpty || other.IsEmpty)
-                return SpatialRelation.DISJOINT;
+                return SpatialRelation.Disjoint;
             if (other is IPoint)
-                return this.Equals(other) ? SpatialRelation.INTERSECTS : SpatialRelation.DISJOINT;
+                return this.Equals(other) ? SpatialRelation.Intersects : SpatialRelation.Disjoint;
             return other.Relate(this).Transpose();
         }
 

--- a/Spatial4n.Core/Shapes/Impl/RectangleImpl.cs
+++ b/Spatial4n.Core/Shapes/Impl/RectangleImpl.cs
@@ -159,7 +159,7 @@ namespace Spatial4n.Core.Shapes.Impl
         public virtual SpatialRelation Relate(IShape other)
         {
             if (IsEmpty || other.IsEmpty)
-                return SpatialRelation.DISJOINT;
+                return SpatialRelation.Disjoint;
             var point = other as IPoint;
             if (point != null)
             {
@@ -176,7 +176,7 @@ namespace Spatial4n.Core.Shapes.Impl
         public virtual SpatialRelation Relate(IPoint point)
         {
             if (point.Y > MaxY || point.Y < MinY)
-                return SpatialRelation.DISJOINT;
+                return SpatialRelation.Disjoint;
             //  all the below logic is rather unfortunate but some dateline cases demand it
             double minX = this.minX;
             double maxX = this.maxX;
@@ -200,23 +200,23 @@ namespace Spatial4n.Core.Shapes.Impl
                 }
                 else
                 {
-                    return SpatialRelation.CONTAINS; //short-circuit
+                    return SpatialRelation.Contains; //short-circuit
                 }
             }
             if (pX < minX || pX > maxX)
-                return SpatialRelation.DISJOINT;
-            return SpatialRelation.CONTAINS;
+                return SpatialRelation.Disjoint;
+            return SpatialRelation.Contains;
         }
 
         public virtual SpatialRelation Relate(IRectangle rect)
         {
             SpatialRelation yIntersect = RelateYRange(rect.MinY, rect.MaxY);
-            if (yIntersect == SpatialRelation.DISJOINT)
-                return SpatialRelation.DISJOINT;
+            if (yIntersect == SpatialRelation.Disjoint)
+                return SpatialRelation.Disjoint;
 
             SpatialRelation xIntersect = RelateXRange(rect.MinX, rect.MaxX);
-            if (xIntersect == SpatialRelation.DISJOINT)
-                return SpatialRelation.DISJOINT;
+            if (xIntersect == SpatialRelation.Disjoint)
+                return SpatialRelation.Disjoint;
 
             if (xIntersect == yIntersect)//in agreement
                 return xIntersect;
@@ -227,7 +227,7 @@ namespace Spatial4n.Core.Shapes.Impl
             if (MinY == rect.MinY && MaxY == rect.MaxY)
                 return xIntersect;
 
-            return SpatialRelation.INTERSECTS;
+            return SpatialRelation.Intersects;
         }
 
         //TODO might this utility move to SpatialRelation ?
@@ -235,20 +235,20 @@ namespace Spatial4n.Core.Shapes.Impl
         {
             if (ext_min > int_max || ext_max < int_min)
             {
-                return SpatialRelation.DISJOINT;
+                return SpatialRelation.Disjoint;
             }
 
             if (ext_min >= int_min && ext_max <= int_max)
             {
-                return SpatialRelation.CONTAINS;
+                return SpatialRelation.Contains;
             }
 
             if (ext_min <= int_min && ext_max >= int_max)
             {
-                return SpatialRelation.WITHIN;
+                return SpatialRelation.Within;
             }
 
-            return SpatialRelation.INTERSECTS;
+            return SpatialRelation.Intersects;
         }
 
         public virtual SpatialRelation RelateYRange(double ext_minY, double ext_maxY)
@@ -266,7 +266,7 @@ namespace Spatial4n.Core.Shapes.Impl
                 //unwrap dateline, plus do world-wrap short circuit
                 double rawWidth = maxX - minX;
                 if (rawWidth == 360)
-                    return SpatialRelation.CONTAINS;
+                    return SpatialRelation.Contains;
                 if (rawWidth < 0)
                 {
                     maxX = minX + (rawWidth + 360);
@@ -274,7 +274,7 @@ namespace Spatial4n.Core.Shapes.Impl
 
                 double ext_rawWidth = ext_maxX - ext_minX;
                 if (ext_rawWidth == 360)
-                    return SpatialRelation.WITHIN;
+                    return SpatialRelation.Within;
                 if (ext_rawWidth < 0)
                 {
                     ext_maxX = ext_minX + (ext_rawWidth + 360);

--- a/Spatial4n.Core/Shapes/Shape.cs
+++ b/Spatial4n.Core/Shapes/Shape.cs
@@ -35,17 +35,17 @@ namespace Spatial4n.Core.Shapes
         /// <summary>
         /// Describe the relationship between the two objects.  For example
         /// <list type="bullet">
-        ///   <item>this is <see cref="SpatialRelation.WITHIN"/> other</item>
-        ///   <item>this <see cref="SpatialRelation.CONTAINS"/> other</item>
-        ///   <item>this is <see cref="SpatialRelation.DISJOINT"/> other</item>
-        ///   <item>this <see cref="SpatialRelation.INTERSECTS"/> other</item>
+        ///   <item>this is <see cref="SpatialRelation.Within"/> other</item>
+        ///   <item>this <see cref="SpatialRelation.Contains"/> other</item>
+        ///   <item>this is <see cref="SpatialRelation.Disjoint"/> other</item>
+        ///   <item>this <see cref="SpatialRelation.Intersects"/> other</item>
         /// </list>
-        /// Note that a <see cref="IShape"/> implementation may choose to return <see cref="SpatialRelation.INTERSECTS"/> when the
-        /// true answer is <see cref="SpatialRelation.WITHIN"/> or <see cref="SpatialRelation.CONTAINS"/> for performance reasons. If a shape does
+        /// Note that a <see cref="IShape"/> implementation may choose to return <see cref="SpatialRelation.Intersects"/> when the
+        /// true answer is <see cref="SpatialRelation.Within"/> or <see cref="SpatialRelation.Contains"/> for performance reasons. If a shape does
         /// this then it <i>must</i> document when it does.  Ideally the shape will not
         /// do this approximation in all circumstances, just sometimes.
         /// <p />
-        /// If the shapes are equal then the result is <see cref="SpatialRelation.CONTAINS"/> (preferred) or <see cref="SpatialRelation.WITHIN"/>.
+        /// If the shapes are equal then the result is <see cref="SpatialRelation.Contains"/> (preferred) or <see cref="SpatialRelation.Within"/>.
         /// </summary>
         SpatialRelation Relate(IShape other);
 
@@ -53,7 +53,7 @@ namespace Spatial4n.Core.Shapes
         /// Get the bounding box for this <see cref="IShape"/>. This means the shape is within the
         /// bounding box and that it touches each side of the rectangle.
         /// <p/>
-        /// Postcondition: <c>this.BoundingBox.Relate(this) == SpatialRelation.CONTAINS</c>
+        /// Postcondition: <c>this.BoundingBox.Relate(this) == SpatialRelation.Contains</c>
         /// </summary>
         IRectangle BoundingBox { get; }
 
@@ -77,7 +77,7 @@ namespace Spatial4n.Core.Shapes
         /// Returns the center point of this shape. This is usually the same as
         /// <c>BoundingBox.Center</c> but it doesn't have to be.
         /// <para/>
-        /// Postcondition: <c>this.Relate(this.Center) == SpatialContext.CONTAINS</c>
+        /// Postcondition: <c>this.Relate(this.Center) == SpatialContext.Contains</c>
         /// </summary>
         IPoint Center { get; }
 

--- a/Spatial4n.Core/Shapes/ShapeCollection.cs
+++ b/Spatial4n.Core/Shapes/ShapeCollection.cs
@@ -132,7 +132,7 @@ namespace Spatial4n.Core.Shapes
         public virtual SpatialRelation Relate(IShape other)
         {
             SpatialRelation bboxSect = m_bbox.Relate(other);
-            if (bboxSect == SpatialRelation.DISJOINT || bboxSect == SpatialRelation.WITHIN)
+            if (bboxSect == SpatialRelation.Disjoint || bboxSect == SpatialRelation.Within)
                 return bboxSect;
 
             bool containsWillShortCircuit = (other is IPoint) ||
@@ -152,20 +152,20 @@ namespace Spatial4n.Core.Shapes
                     sect = sect.Value.Combine(nextSect);
                 }
 
-                if (sect == SpatialRelation.INTERSECTS)
-                    return SpatialRelation.INTERSECTS;
+                if (sect == SpatialRelation.Intersects)
+                    return SpatialRelation.Intersects;
 
-                if (sect == SpatialRelation.CONTAINS && containsWillShortCircuit)
-                    return SpatialRelation.CONTAINS;
+                if (sect == SpatialRelation.Contains && containsWillShortCircuit)
+                    return SpatialRelation.Contains;
             }
             return sect.GetValueOrDefault(); // TODO: What to return if null??
         }
 
         /// <summary>
         /// Called by <see cref="Relate(IShape)"/> to determine whether to return early if it finds
-        /// <see cref="SpatialRelation.CONTAINS"/>, instead of checking the remaining shapes. It will do so without
+        /// <see cref="SpatialRelation.Contains"/>, instead of checking the remaining shapes. It will do so without
         /// calling this method if the "other" shape is a Point.  If a remaining shape
-        /// finds <see cref="SpatialRelation.INTERSECTS"/>, then <see cref="SpatialRelation.INTERSECTS"/> will be returned.  The only problem with
+        /// finds <see cref="SpatialRelation.Intersects"/>, then <see cref="SpatialRelation.Intersects"/> will be returned.  The only problem with
         /// this returning true is that if some of the shapes overlap, it's possible
         /// that the result of <see cref="Relate(IShape)"/> could be dependent on the order of the shapes,
         /// which could be unexpected / wrong depending on the application. The default

--- a/Spatial4n.Core/Shapes/ShapeCollection.cs
+++ b/Spatial4n.Core/Shapes/ShapeCollection.cs
@@ -329,7 +329,7 @@ namespace Spatial4n.Core.Shapes
 
         #region Added for .NET support of the IShape interface
 
-        public virtual bool IsEmpty => !m_shapes.Any();
+        public virtual bool IsEmpty => m_shapes.Count == 0;
 
         #endregion
     }

--- a/Spatial4n.Core/Shapes/ShapeCollection.cs
+++ b/Spatial4n.Core/Shapes/ShapeCollection.cs
@@ -31,7 +31,7 @@ namespace Spatial4n.Core.Shapes
     /// retained if an application requires it, although logically it's treated as an
     /// unordered Set, mostly.
     /// <para>
-    /// Ideally, <see cref="Relate(Shapes.IShape)"/> should return the same result no matter what
+    /// Ideally, <see cref="Relate(IShape)"/> should return the same result no matter what
     /// the shape order is, although the default implementation can be order
     /// dependent when the shapes overlap; see <see cref="RelateContainsShortCircuits()"/>.
     /// To improve performance slightly, the caller could order the shapes by
@@ -65,7 +65,7 @@ namespace Spatial4n.Core.Shapes
             this.m_bbox = ComputeBoundingBox(shapes, ctx);
         }
 
-        protected virtual IRectangle ComputeBoundingBox(ICollection<Shapes.IShape> shapes, SpatialContext ctx)
+        protected virtual IRectangle ComputeBoundingBox(ICollection<IShape> shapes, SpatialContext ctx)
         {
             if (!shapes.Any())
                 return ctx.MakeRectangle(double.NaN, double.NaN, double.NaN, double.NaN);
@@ -106,7 +106,7 @@ namespace Spatial4n.Core.Shapes
         {
             get
             {
-                foreach (Shapes.IShape geom in m_shapes)
+                foreach (IShape geom in m_shapes)
                 {
                     if (geom.HasArea)
                     {
@@ -120,8 +120,8 @@ namespace Spatial4n.Core.Shapes
 
         public virtual IShape GetBuffered(double distance, SpatialContext ctx)
         {
-            IList<Shapes.IShape> bufColl = new List<Shapes.IShape>(Count);
-            foreach (Shapes.IShape shape in m_shapes)
+            IList<IShape> bufColl = new List<IShape>(Count);
+            foreach (IShape shape in m_shapes)
             {
                 bufColl.Add(shape.GetBuffered(distance, ctx));
             }
@@ -138,7 +138,7 @@ namespace Spatial4n.Core.Shapes
             bool containsWillShortCircuit = (other is IPoint) ||
                 RelateContainsShortCircuits();
             SpatialRelation? sect = null;
-            foreach (Shapes.IShape shape in m_shapes)
+            foreach (IShape shape in m_shapes)
             {
                 SpatialRelation nextSect = shape.Relate(other);
 
@@ -208,7 +208,7 @@ namespace Spatial4n.Core.Shapes
         {
             double MAX_AREA = m_bbox.GetArea(ctx);
             double sum = 0;
-            foreach (Shapes.IShape geom in m_shapes)
+            foreach (IShape geom in m_shapes)
             {
                 sum += geom.GetArea(ctx);
                 if (sum >= MAX_AREA)
@@ -254,10 +254,11 @@ namespace Spatial4n.Core.Shapes
 
         private bool ValueEquals(ShapeCollection other)
         {
-            var iter = other.GetEnumerator();
+            using var iter = other.GetEnumerator();
             foreach (IShape value in this)
             {
-                iter.MoveNext();
+                if (!iter.MoveNext())
+                    return false;
                 if (!value.Equals(iter.Current))
                 {
                     return false;

--- a/Spatial4n.Core/Shapes/SpatialRelation.cs
+++ b/Spatial4n.Core/Shapes/SpatialRelation.cs
@@ -15,16 +15,18 @@
  * limitations under the License.
  */
 
+using System;
+
 namespace Spatial4n.Core.Shapes
 {
     /// <summary>
     /// The set of spatial relationships. Naming is consistent with OGC spec conventions as seen in SQL/MM and others.
     /// <para>
-    /// No equality case.  If two <see cref="IShape"/> instances are equal then the result might be <see cref="CONTAINS"/> (preferred) or <see cref="WITHIN"/>.  
+    /// No equality case.  If two <see cref="IShape"/> instances are equal then the result might be <see cref="Contains"/> (preferred) or <see cref="Within"/>.
     /// Client logic may have to be aware of this edge condition; Spatial4n testing certainly does.
     /// </para>
     /// <para></para>
-    /// The "CONTAINS" and "WITHIN" wording here is inconsistent with OGC; these here map to OGC
+    /// The <see cref="Contains"/> and <see cref="Within"/> wording here is inconsistent with OGC; these here map to OGC
     /// "COVERS" and "COVERED BY", respectively. The distinction is in the boundaries; in Spatial4n
     /// there is no boundary distinction -- boundaries are part of the shape as if it was an "interior",
     /// with respect to OGC's terminology.
@@ -38,62 +40,74 @@ namespace Spatial4n.Core.Shapes
         /// Set to zero explicitly to ensure it will be the default value for an 
         /// uninitialized SpatialRelation variable.
         /// </summary>
+        None = 0,
+        [Obsolete("Use None instead. This const will be removed in 0.5.0."), System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
         NOT_SET = 0,
 
-
         /// <summary>
-        /// The shape is within the target geometry. It's the converse of <see cref="CONTAINS"/>.
+        /// The shape is within the target geometry. It's the converse of <see cref="Contains"/>.
         /// Boundaries of shapes count too.  OGC specs refer to this relation as "COVERED BY";
-        /// <see cref="WITHIN"/> is differentiated thereby not including boundaries.
+        /// <see cref="Within"/> is differentiated thereby not including boundaries.
         /// </summary>
-		WITHIN,
+        Within = 1,
+        [Obsolete("Use Within instead. This const will be removed in 0.5.0."), System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never), CLSCompliant(false)]
+        WITHIN = 1,
 
         /// <summary>
-        /// The shape contains the target geometry. It's the converse of <see cref="WITHIN"/>.
+        /// The shape contains the target geometry. It's the converse of <see cref="Within"/>.
         /// Boundaries of shapes count too.  OGC specs refer to this relation as "COVERS";
-        /// <see cref="CONTAINS"/> is differentiated thereby not including boundaries.
+        /// <see cref="Contains"/> is differentiated thereby not including boundaries.
         /// </summary>
-		CONTAINS,
+        Contains = 2,
+        [Obsolete("Use Contains instead. This const will be removed in 0.5.0."), System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never), CLSCompliant(false)]
+        CONTAINS = 2,
 
         /// <summary>
         /// The shape shares no point in common with the target shape.
         /// </summary>
-		DISJOINT,
+        Disjoint = 3,
+        [Obsolete("Use Disjoint instead. This const will be removed in 0.5.0."), System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never), CLSCompliant(false)]
+        DISJOINT = 3,
 
         /// <summary>
         /// The shape shares some points/overlap with the target shape, and the relation is
-        /// not more specifically <see cref="WITHIN"/> or <see cref="CONTAINS"/>.
+        /// not more specifically <see cref="Within"/> or <see cref="Contains"/>.
         /// </summary>
-		INTERSECTS,
+        Intersects = 4,
+        [Obsolete("Use Intersects instead. This const will be removed in 0.5.0."), System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never), CLSCompliant(false)]
+        INTERSECTS = 4,
         //Don't have these: TOUCHES, CROSSES, OVERLAPS, nor distinction between CONTAINS/COVERS
     }
 
-    public static class SpatialRelationComparators
+    /// <summary>
+    /// Extensions to <see cref="SpatialRelation"/>.
+    /// </summary>
+    public static class SpatialRelationExtensions
     {
         /// <summary>
         /// Given the result of <c>shapeA.Relate(shapeB)</c>, transposing that
         /// result should yield the result of <c>shapeB.Relate(shapeA)</c>. There
         /// is a corner case is when the shapes are equal, in which case actually
-        /// flipping the Relate() call will result in the same value -- either CONTAINS
-        /// or WITHIN; this method can't possible check for that so the caller might
+        /// flipping the Relate() call will result in the same value -- either <see cref="SpatialRelation.Contains"/>
+        /// or <see cref="SpatialRelation.Within"/>; this method can't possible check for that so the caller might
         /// have to.
         /// </summary>
-        public static SpatialRelation Transpose(this SpatialRelation sr)
+        public static SpatialRelation Transpose(this SpatialRelation relation)
         {
-            switch (sr)
+            return relation switch
             {
-                case SpatialRelation.CONTAINS: return SpatialRelation.WITHIN;
-                case SpatialRelation.WITHIN: return SpatialRelation.CONTAINS;
-                default: return sr;
-            }
+                SpatialRelation.Contains => SpatialRelation.Within,
+                SpatialRelation.Within => SpatialRelation.Contains,
+                _ => relation,
+            };
         }
 
         /// <summary>
-        /// If you were to call aShape.Relate(bShape) and aShape.Relate(cShape), you 
-        /// could call this to merge the intersect results as if bShape &amp; cShape were 
+        /// If you were to call <c>aShape.Relate(bShape)</c> and <c>aShape.Relate(cShape)</c>, you
+        /// could call this to merge the intersect results as if <c>bShape &amp; cShape</c> were
         /// combined into <see cref="ShapeCollection"/>.
         /// </summary>
-        public static SpatialRelation Combine(this SpatialRelation @this, SpatialRelation other)
+        public static SpatialRelation Combine(this SpatialRelation relation, SpatialRelation other)
         {
             // You can think of this algorithm as a state transition / automata.
             // 1. The answer must be the same no matter what the order is.
@@ -103,20 +117,20 @@ namespace Spatial4n.Core.Shapes
             // 5. A CONTAINS + WITHIN == INTERSECTS (done). (weird scenario)
             // 6. X + X == X.
 
-            if (other == @this)
-                return @this;
-            if (@this == SpatialRelation.DISJOINT && other == SpatialRelation.CONTAINS
-                || @this == SpatialRelation.CONTAINS && other == SpatialRelation.DISJOINT)
-                return SpatialRelation.CONTAINS;
-            return SpatialRelation.INTERSECTS;
+            if (other == relation)
+                return relation;
+            if (relation == SpatialRelation.Disjoint && other == SpatialRelation.Contains
+                || relation == SpatialRelation.Contains && other == SpatialRelation.Disjoint)
+                return SpatialRelation.Contains;
+            return SpatialRelation.Intersects;
         }
 
         /// <summary>
-        /// Not DISJOINT, i.e. there is some sort of intersection.
+        /// Not <see cref="SpatialRelation.Disjoint"/>, i.e. there is some sort of intersection.
         /// </summary>
-        public static bool Intersects(this SpatialRelation @this)
+        public static bool Intersects(this SpatialRelation relation)
         {
-            return @this != SpatialRelation.DISJOINT;
+            return relation != SpatialRelation.Disjoint;
         }
 
         /// <summary>
@@ -125,18 +139,35 @@ namespace Spatial4n.Core.Shapes
         /// <c>Inverse(shape)</c> is theoretically the opposite area covered by a
         /// shape, i.e. everywhere but where the shape is.
         /// <para/>
-        /// Note that it's not commutative!  <code>WITHIN.inverse().inverse() !=
-        /// WITHIN</code>.
+        /// Note that it's not commutative!  <c>SpatialRelation.Within.Inverse().Inverse() !=
+        /// SpatialRelation.Within</c>.
         /// </summary>
-        public static SpatialRelation Inverse(this SpatialRelation @this)
+        public static SpatialRelation Inverse(this SpatialRelation relation)
         {
-            switch (@this)
+            return relation switch
             {
-                case SpatialRelation.DISJOINT: return SpatialRelation.CONTAINS;
-                case SpatialRelation.CONTAINS: return SpatialRelation.DISJOINT;
-                case SpatialRelation.WITHIN: return SpatialRelation.INTERSECTS;//not commutative!
-            }
-            return SpatialRelation.INTERSECTS;
+                SpatialRelation.Disjoint => SpatialRelation.Contains,
+                SpatialRelation.Contains => SpatialRelation.Disjoint,
+                SpatialRelation.Within => SpatialRelation.Intersects,//not commutative!
+                _ => SpatialRelation.Intersects,
+            };
         }
+    }
+
+    [Obsolete("Use SpatialRelationExtensions instead. This will be removed in 0.5.0."), System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public static class SpatialRelationComparators
+    {
+
+        [Obsolete("Use SpatialRelationExtensions.Transpose() instead. This will be removed in 0.5.0."), System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+        public static SpatialRelation Transpose(SpatialRelation sr) => sr.Transpose();
+
+        [Obsolete("Use SpatialRelationExtensions.Combine() instead. This will be removed in 0.5.0."), System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+        public static SpatialRelation Combine(SpatialRelation @this, SpatialRelation other) => @this.Combine(other);
+
+        [Obsolete("Use SpatialRelationExtensions.Intersects() instead. This will be removed in 0.5.0."), System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+        public static bool Intersects(SpatialRelation @this) => @this.Intersects();
+
+        [Obsolete("Use SpatialRelationExtensions.Inverse() instead. This will be removed in 0.5.0."), System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+        public static SpatialRelation Inverse(SpatialRelation @this) => @this.Inverse();
     }
 }

--- a/Spatial4n.Tests/distance/TestDistances.cs
+++ b/Spatial4n.Tests/distance/TestDistances.cs
@@ -67,7 +67,7 @@ namespace Spatial4n.Core.Distance
                 Assert.True(Dc().Distance(pCtr, pTgt) < d);
                 //since the pairwise distance is less than d, a bounding box from ctr with d should contain pTgt.
                 IRectangle r = Dc().CalcBoxByDistFromPt(pCtr, d, ctx, null);
-                Assert.Equal(SpatialRelation.CONTAINS, r.Relate(pTgt));
+                Assert.Equal(SpatialRelation.Contains, r.Relate(pTgt));
                 CheckBBox(pCtr, d);
             }
 

--- a/Spatial4n.Tests/distance/TestDistances.cs
+++ b/Spatial4n.Tests/distance/TestDistances.cs
@@ -49,11 +49,11 @@ namespace Spatial4n.Core.Distance
         {
             //See to verify: from http://www.movable-type.co.uk/scripts/latlong.html
             IPoint ctr = PLL(0, 100);
-            CustomAssert.EqualWithDelta(11100, Dc().Distance(ctr, PLL(10, 0)) * DistanceUtils.DEG_TO_KM, 3);
+            CustomAssert.EqualWithDelta(11100, Dc().Distance(ctr, PLL(10, 0)) * DistanceUtils.DegreesToKilometers, 3);
             double deg = Dc().Distance(ctr, PLL(10, -160));
-            CustomAssert.EqualWithDelta(11100, deg * DistanceUtils.DEG_TO_KM, 3);
+            CustomAssert.EqualWithDelta(11100, deg * DistanceUtils.DegreesToKilometers, 3);
 
-            CustomAssert.EqualWithDelta(314.40338, Dc().Distance(PLL(1, 2), PLL(3, 4)) * DistanceUtils.DEG_TO_KM, EPS);
+            CustomAssert.EqualWithDelta(314.40338, Dc().Distance(PLL(1, 2), PLL(3, 4)) * DistanceUtils.DegreesToKilometers, EPS);
         }
 
         [Fact]
@@ -61,7 +61,7 @@ namespace Spatial4n.Core.Distance
         {
             //first test regression
             {
-                double d = 6894.1 * DistanceUtils.KM_TO_DEG;
+                double d = 6894.1 * DistanceUtils.KilometersToDegrees;
                 IPoint pCtr = PLL(-20, 84);
                 IPoint pTgt = PLL(-42, 15);
                 Assert.True(Dc().Distance(pCtr, pTgt) < d);
@@ -74,17 +74,17 @@ namespace Spatial4n.Core.Distance
             CustomAssert.EqualWithDelta(/*"0 dist, horiz line",*/
                 -45, Dc().CalcBoxByDistFromPt_yHorizAxisDEG(ctx.MakePoint(-180, -45), 0, ctx), 0);
 
-            double MAXDIST = (double)180 * DistanceUtils.DEG_TO_KM;
+            double MAXDIST = (double)180 * DistanceUtils.DegreesToKilometers;
             CheckBBox(ctx.MakePoint(0, 0), MAXDIST);
             CheckBBox(ctx.MakePoint(0, 0), MAXDIST * 0.999999);
             CheckBBox(ctx.MakePoint(0, 0), 0);
             CheckBBox(ctx.MakePoint(0, 0), 0.000001);
             CheckBBox(ctx.MakePoint(0, 90), 0.000001);
             CheckBBox(ctx.MakePoint(-32.7, -5.42), 9829);
-            CheckBBox(ctx.MakePoint(0, 90 - 20), (double)20 * DistanceUtils.DEG_TO_KM);
+            CheckBBox(ctx.MakePoint(0, 90 - 20), (double)20 * DistanceUtils.DegreesToKilometers);
             {
                 double d = 0.010;//10m
-                CheckBBox(ctx.MakePoint(0, 90 - (d + 0.001) * DistanceUtils.KM_TO_DEG), d);
+                CheckBBox(ctx.MakePoint(0, 90 - (d + 0.001) * DistanceUtils.KilometersToDegrees), d);
             }
 
             for (int T = 0; T < 100; T++)
@@ -101,7 +101,7 @@ namespace Spatial4n.Core.Distance
         private void CheckBBox(IPoint ctr, double distKm)
         {
             string msg = "ctr: " + ctr + " distKm: " + distKm;
-            double dist = distKm * DistanceUtils.KM_TO_DEG;
+            double dist = distKm * DistanceUtils.KilometersToDegrees;
 
             IRectangle r = Dc().CalcBoxByDistFromPt(ctr, dist, ctx, null);
             double horizAxisLat = Dc().CalcBoxByDistFromPt_yHorizAxisDEG(ctr, dist, ctx);
@@ -112,25 +112,25 @@ namespace Spatial4n.Core.Distance
             if (r.Width >= 180)
             {
                 double deg = Dc().Distance(ctr, r.MinX, r.MaxY == 90 ? 90 : -90);
-                double calcDistKm = deg * DistanceUtils.DEG_TO_KM;
+                double calcDistKm = deg * DistanceUtils.DegreesToKilometers;
                 Assert.True(/*msg,*/ calcDistKm <= distKm + EPS);
                 //horizAxisLat is meaningless in this context
             }
             else
             {
                 IPoint tPt = FindClosestPointOnVertToPoint(r.MinX, r.MinY, r.MaxY, ctr);
-                double calcDistKm = Dc().Distance(ctr, tPt) * DistanceUtils.DEG_TO_KM;
+                double calcDistKm = Dc().Distance(ctr, tPt) * DistanceUtils.DegreesToKilometers;
                 CustomAssert.EqualWithDelta(/*msg,*/ distKm, calcDistKm, EPS);
                 CustomAssert.EqualWithDelta(/*msg,*/ tPt.Y, horizAxisLat, EPS);
             }
 
             //vertical
-            double topDistKm = Dc().Distance(ctr, ctr.X, r.MaxY) * DistanceUtils.DEG_TO_KM;
+            double topDistKm = Dc().Distance(ctr, ctr.X, r.MaxY) * DistanceUtils.DegreesToKilometers;
             if (r.MaxY == 90)
                 Assert.True(/*msg,*/ topDistKm <= distKm + EPS);
             else
                 CustomAssert.EqualWithDelta(msg, distKm, topDistKm, EPS);
-            double botDistKm = Dc().Distance(ctr, ctr.X, r.MinY) * DistanceUtils.DEG_TO_KM;
+            double botDistKm = Dc().Distance(ctr, ctr.X, r.MinY) * DistanceUtils.DegreesToKilometers;
             if (r.MinY == -90)
                 Assert.True(/*msg,*/ botDistKm <= distKm + EPS);
             else
@@ -198,7 +198,7 @@ namespace Spatial4n.Core.Distance
             //    assertEqualsRatio(dist, calcDist);
             //}
 
-            double maxDistKm = (double)180 * DistanceUtils.DEG_TO_KM;
+            double maxDistKm = (double)180 * DistanceUtils.DegreesToKilometers;
             for (int i = 0; i < 1000; i++)
             {
                 int dist = random.Next((int)maxDistKm);
@@ -219,8 +219,8 @@ namespace Spatial4n.Core.Distance
                 IPoint p2 = Dc().PointOnBearing(c, 0, angDEG, ctx, null);
                 Assert.Equal(c, p2);
 
-                p2 = Dc().PointOnBearing(c, distKm * DistanceUtils.KM_TO_DEG, angDEG, ctx, null);
-                double calcDistKm = Dc().Distance(c, p2) * DistanceUtils.DEG_TO_KM;
+                p2 = Dc().PointOnBearing(c, distKm * DistanceUtils.KilometersToDegrees, angDEG, ctx, null);
+                double calcDistKm = Dc().Distance(c, p2) * DistanceUtils.DegreesToKilometers;
                 AssertEqualsRatio(distKm, calcDistKm);
             }
         }
@@ -299,12 +299,12 @@ namespace Spatial4n.Core.Distance
         {
             AssertDistanceConversionImpl(0);
             AssertDistanceConversionImpl(500);
-            AssertDistanceConversionImpl(DistanceUtils.EARTH_MEAN_RADIUS_KM);
+            AssertDistanceConversionImpl(DistanceUtils.EarthMeanRadiusKilometers);
         }
 
         private void AssertDistanceConversionImpl(double dist)
         {
-            double radius = DistanceUtils.EARTH_MEAN_RADIUS_KM;
+            double radius = DistanceUtils.EarthMeanRadiusKilometers;
             //test back & forth conversion for both
             double distRAD = DistanceUtils.Dist2Radians(dist, radius);
             CustomAssert.EqualWithDelta(dist, DistanceUtils.Radians2Dist(distRAD, radius), EPS);
@@ -315,7 +315,7 @@ namespace Spatial4n.Core.Distance
             //test point on bearing
             CustomAssert.EqualWithDelta(
                 DistanceUtils.PointOnBearingRAD(0, 0, DistanceUtils.Dist2Radians(dist, radius),
-                    DistanceUtils.DEG_90_AS_RADS, ctx, new Point(0, 0, ctx)).X,
+                    DistanceUtils.Degrees90AsRadians, ctx, new Point(0, 0, ctx)).X,
                 distRAD, 10e-5);
         }
 
@@ -327,7 +327,7 @@ namespace Spatial4n.Core.Distance
         [Fact]
         public virtual void TestArea()
         {
-            double radius = DistanceUtils.EARTH_MEAN_RADIUS_KM * DistanceUtils.KM_TO_DEG;
+            double radius = DistanceUtils.EarthMeanRadiusKilometers * DistanceUtils.KilometersToDegrees;
             //surface of a sphere is 4 * pi * r^2
             double earthArea = 4 * Math.PI * radius * radius;
 

--- a/Spatial4n.Tests/io/NtsWktShapeParserTest.cs
+++ b/Spatial4n.Tests/io/NtsWktShapeParserTest.cs
@@ -204,7 +204,7 @@ namespace Spatial4n.Core.IO
             IShape cvxHull = ctx.ReadShapeFromWkt(wkt);
             Assert.True(cvxHull.GetArea(ctx) > 0);
 
-            Assert.Equal(SpatialRelation.CONTAINS, cvxHull.Relate(buffer0));
+            Assert.Equal(SpatialRelation.Contains, cvxHull.Relate(buffer0));
 
             factory = new NtsSpatialContextFactory();
             factory.validationRule = ValidationRule.None;

--- a/Spatial4n.Tests/shape/AbstractTestShapes.cs
+++ b/Spatial4n.Tests/shape/AbstractTestShapes.cs
@@ -78,7 +78,7 @@ namespace Spatial4n.Core.Shape
             IPoint center = r.Center;
             msg += " ctr:" + center;
             //System.out.println(msg);
-            AssertRelation(msg, SpatialRelation.CONTAINS, r, center);
+            AssertRelation(msg, SpatialRelation.Contains, r, center);
 
             IDistanceCalculator dc = ctx.DistCalc;
             double dUR = dc.Distance(center, r.MaxX, r.MaxY);
@@ -113,10 +113,10 @@ namespace Spatial4n.Core.Shape
                         for (double right2 = left2; right2 <= right; right2 += INCR)
                         {
                             IRectangle r2 = MakeNormRect(left2, right2, -Y, Y);
-                            AssertRelation(null, SpatialRelation.CONTAINS, r, r2);
+                            AssertRelation(null, SpatialRelation.Contains, r, r2);
 
                             //test point contains
-                            AssertRelation(null, SpatialRelation.CONTAINS, r, r2.Center);
+                            AssertRelation(null, SpatialRelation.Contains, r, r2.Center);
                         }
                     }
 
@@ -124,13 +124,13 @@ namespace Spatial4n.Core.Shape
                     for (double left2 = right + INCR; left2 - left < 360; left2 += INCR)
                     {
                         //test point disjoint
-                        AssertRelation(null, SpatialRelation.DISJOINT, r, ctx.MakePoint(
+                        AssertRelation(null, SpatialRelation.Disjoint, r, ctx.MakePoint(
                             NormX(left2), random.Next(-90, 90)));
 
                         for (double right2 = left2; right2 - left < 360; right2 += INCR)
                         {
                             IRectangle r2 = MakeNormRect(left2, right2, -Y, Y);
-                            AssertRelation(null, SpatialRelation.DISJOINT, r, r2);
+                            AssertRelation(null, SpatialRelation.Disjoint, r, r2);
                         }
                     }
                     //test intersect
@@ -139,7 +139,7 @@ namespace Spatial4n.Core.Shape
                         for (double right2 = right + INCR; right2 - left < 360; right2 += INCR)
                         {
                             IRectangle r2 = MakeNormRect(left2, right2, -Y, Y);
-                            AssertRelation(null, SpatialRelation.INTERSECTS, r, r2);
+                            AssertRelation(null, SpatialRelation.Intersects, r, r2);
                         }
                     }
 
@@ -167,8 +167,8 @@ namespace Spatial4n.Core.Shape
                 AssertEqualsRatio(msg, bbox.Height, dist * 2);
                 AssertEqualsRatio(msg, bbox.Width, dist * 2);
             }
-            AssertRelation(msg, SpatialRelation.CONTAINS, c, c.Center);
-            AssertRelation(msg, SpatialRelation.CONTAINS, bbox, c);
+            AssertRelation(msg, SpatialRelation.Contains, c, c.Center);
+            AssertRelation(msg, SpatialRelation.Contains, bbox, c);
         }
 
         private class RectIntersectionAnonymousHelper : RectIntersectionTestHelper
@@ -247,10 +247,10 @@ namespace Spatial4n.Core.Shape
             Assert.True(emptyRect.IsEmpty);
             AssertEquals(emptyRect, emptyShape.BoundingBox);
             AssertEquals(emptyPt, emptyShape.Center);
-            AssertRelation("EMPTY", SpatialRelation.DISJOINT, emptyShape, emptyPt);
-            AssertRelation("EMPTY", SpatialRelation.DISJOINT, emptyShape, RandomPoint());
-            AssertRelation("EMPTY", SpatialRelation.DISJOINT, emptyShape, emptyRect);
-            AssertRelation("EMPTY", SpatialRelation.DISJOINT, emptyShape, RandomRectangle(10));
+            AssertRelation("EMPTY", SpatialRelation.Disjoint, emptyShape, emptyPt);
+            AssertRelation("EMPTY", SpatialRelation.Disjoint, emptyShape, RandomPoint());
+            AssertRelation("EMPTY", SpatialRelation.Disjoint, emptyShape, emptyRect);
+            AssertRelation("EMPTY", SpatialRelation.Disjoint, emptyShape, RandomRectangle(10));
             Assert.True(emptyShape.GetBuffered(random.Next(4 + 1), ctx).IsEmpty);
         }
     }

--- a/Spatial4n.Tests/shape/NtsGeometryTest.cs
+++ b/Spatial4n.Tests/shape/NtsGeometryTest.cs
@@ -121,15 +121,15 @@ namespace Spatial4n.Core.Shape
             NtsGeometry lineI = (NtsGeometry)ctx.ReadShapeFromWkt("LINESTRING(10 0, 20 0)");
 
             if (prepare) @base.Index();
-            AssertRelation(SpatialRelation.CONTAINS, @base, @base);//preferred result as there is no EQUALS
-            AssertRelation(SpatialRelation.INTERSECTS, @base, polyI);
-            AssertRelation(SpatialRelation.CONTAINS, @base, polyW);
-            AssertRelation(SpatialRelation.CONTAINS, @base, pointB);
-            AssertRelation(SpatialRelation.CONTAINS, @base, lineB);
-            AssertRelation(SpatialRelation.INTERSECTS, @base, lineI);
+            AssertRelation(SpatialRelation.Contains, @base, @base);//preferred result as there is no EQUALS
+            AssertRelation(SpatialRelation.Intersects, @base, polyI);
+            AssertRelation(SpatialRelation.Contains, @base, polyW);
+            AssertRelation(SpatialRelation.Contains, @base, pointB);
+            AssertRelation(SpatialRelation.Contains, @base, lineB);
+            AssertRelation(SpatialRelation.Intersects, @base, lineI);
             if (prepare) lineB.Index();
-            AssertRelation(SpatialRelation.CONTAINS, lineB, lineB);//line contains itself
-            AssertRelation(SpatialRelation.CONTAINS, lineB, pointB);
+            AssertRelation(SpatialRelation.Contains, lineB, lineB);//line contains itself
+            AssertRelation(SpatialRelation.Contains, lineB, pointB);
         }
 
         [Fact]
@@ -137,7 +137,7 @@ namespace Spatial4n.Core.Shape
         {
             IShape emptyGeom = ctx.ReadShapeFromWkt("POLYGON EMPTY");
             TestEmptiness(emptyGeom);
-            AssertRelation("EMPTY", SpatialRelation.DISJOINT, emptyGeom, POLY_SHAPE);
+            AssertRelation("EMPTY", SpatialRelation.Disjoint, emptyGeom, POLY_SHAPE);
         }
 
         [Fact]
@@ -197,8 +197,8 @@ namespace Spatial4n.Core.Shape
             IntersectionMatrix expectedM = POLY_SHAPE.Geometry.Relate(((NtsSpatialContext)ctx).GetGeometryFrom(shape));
             SpatialRelation expectedSR = NtsGeometry.IntersectionMatrixToSpatialRelation(expectedM);
             //NTS considers a point on a boundary INTERSECTS, not CONTAINS
-            if (expectedSR == SpatialRelation.INTERSECTS && shape is Core.Shapes.IPoint)
-                expectedSR = SpatialRelation.CONTAINS;
+            if (expectedSR == SpatialRelation.Intersects && shape is Core.Shapes.IPoint)
+                expectedSR = SpatialRelation.Contains;
             AssertRelation(null, expectedSR, POLY_SHAPE, shape);
 
             if (ctx.IsGeo)
@@ -239,7 +239,7 @@ namespace Spatial4n.Core.Shape
             // TODO Test contains: 64°12'44.82"N    61°29'5.20"E
             //  64.21245  61.48475
             // FAILS
-            //AssertRelation(null,SpatialRelation.CONTAINS, shape, ctx.makePoint(61.48, 64.21));
+            //AssertRelation(null,SpatialRelation.Contains, shape, ctx.makePoint(61.48, 64.21));
 
             NtsSpatialContextFactory factory = new NtsSpatialContextFactory();
             factory.normWrapLongitude = true;
@@ -262,9 +262,9 @@ namespace Spatial4n.Core.Shape
 
             IShape shape = ctx.ReadShapeFromWkt(wktStr);
 
-            AssertRelation(null, SpatialRelation.CONTAINS, shape,
+            AssertRelation(null, SpatialRelation.Contains, shape,
                     ctx.MakePoint(-179.99, -16.9));
-            AssertRelation(null, SpatialRelation.CONTAINS, shape,
+            AssertRelation(null, SpatialRelation.Contains, shape,
                     ctx.MakePoint(+179.99, -16.9));
             Assert.True(shape.BoundingBox.Width < 5);//smart bbox
             Console.WriteLine("Fiji Area: " + shape.GetArea(ctx));

--- a/Spatial4n.Tests/shape/RandomizedShapeTest.cs
+++ b/Spatial4n.Tests/shape/RandomizedShapeTest.cs
@@ -214,7 +214,7 @@ namespace Spatial4n.Core.Shape
             if (sect == expected)
                 return;
             msg = ((msg == null) ? "" : msg + "\r") + a + " intersect " + b;
-            if (expected == SpatialRelation.WITHIN || expected == SpatialRelation.CONTAINS)
+            if (expected == SpatialRelation.Within || expected == SpatialRelation.Contains)
             {
                 if (a.GetType().Equals(b.GetType())) // they are the same shape type
                     Assert.Equal(/*msg,*/ a, b);
@@ -328,7 +328,7 @@ namespace Spatial4n.Core.Shape
             double d = c.Radius * random.NextDouble();
             double angleDEG = 360 * random.NextDouble();
             IPoint p = ctx.DistCalc.PointOnBearing(c.Center, d, angleDEG, ctx, null);
-            Assert.Equal(SpatialRelation.CONTAINS, c.Relate(p));
+            Assert.Equal(SpatialRelation.Contains, c.Relate(p));
             return p;
         }
 
@@ -339,7 +339,7 @@ namespace Spatial4n.Core.Shape
             x = NormX(x);
             y = NormY(y);
             IPoint p = ctx.MakePoint(x, y);
-            Assert.Equal(SpatialRelation.CONTAINS, r.Relate(p));
+            Assert.Equal(SpatialRelation.Contains, r.Relate(p));
             return p;
         }
 

--- a/Spatial4n.Tests/shape/RectIntersectionTestHelper.cs
+++ b/Spatial4n.Tests/shape/RectIntersectionTestHelper.cs
@@ -70,25 +70,25 @@ namespace Spatial4n.Core.Shape
                 {
                     switch (ic)
                     {
-                        case SpatialRelation.CONTAINS:
+                        case SpatialRelation.Contains:
                             i_C++;
                             for (int j = 0; j < AtLeast(10); j++)
                             {
                                 Core.Shapes.IPoint p = RandomPointIn(r);
-                                AssertRelation(null, SpatialRelation.CONTAINS, s, p);
+                                AssertRelation(null, SpatialRelation.Contains, s, p);
                             }
                             break;
 
-                        case SpatialRelation.WITHIN:
+                        case SpatialRelation.Within:
                             i_W++;
                             for (int j = 0; j < AtLeast(10); j++)
                             {
                                 Core.Shapes.IPoint p = RandomPointIn(s);
-                                AssertRelation(null, SpatialRelation.CONTAINS, r, p);
+                                AssertRelation(null, SpatialRelation.Contains, r, p);
                             }
                             break;
 
-                        case SpatialRelation.DISJOINT:
+                        case SpatialRelation.Disjoint:
                             if (!s.BoundingBox.Relate(r).Intersects())
                             {//bboxes are disjoint
                                 i_bboxD++;
@@ -102,11 +102,11 @@ namespace Spatial4n.Core.Shape
                             for (int j = 0; j < AtLeast(10); j++)
                             {
                                 Core.Shapes.IPoint p = RandomPointIn(r);
-                                AssertRelation(null, SpatialRelation.DISJOINT, s, p);
+                                AssertRelation(null, SpatialRelation.Disjoint, s, p);
                             }
                             break;
 
-                        case SpatialRelation.INTERSECTS:
+                        case SpatialRelation.Intersects:
                             i_I++;
                             SpatialRelation? pointR = null;//set once
                             IRectangle randomPointSpace = null;
@@ -123,7 +123,7 @@ namespace Spatial4n.Core.Shape
                                 {
                                     if (randomPointSpace == null)
                                     {
-                                        if (pointR == SpatialRelation.DISJOINT)
+                                        if (pointR == SpatialRelation.Disjoint)
                                         {
                                             randomPointSpace = IntersectRects(r, s.BoundingBox);
                                         }

--- a/Spatial4n.Tests/shape/ShapeCollectionTest.cs
+++ b/Spatial4n.Tests/shape/ShapeCollectionTest.cs
@@ -98,7 +98,7 @@ namespace Spatial4n.Core.Shape
                 {
                     foreach (IRectangle shape in shapes)
                     {
-                        AssertRelation("bbox contains shape", SpatialRelation.CONTAINS, msBbox, shape);
+                        AssertRelation("bbox contains shape", SpatialRelation.Contains, msBbox, shape);
                     }
                 }
                 return shapeCollection;

--- a/Spatial4n.Tests/shape/TestShapes2D.cs
+++ b/Spatial4n.Tests/shape/TestShapes2D.cs
@@ -76,10 +76,10 @@ namespace Spatial4n.Core.Shape
             Assert.True(pt.Equals(center));
             //Assert.Equal(/*msg,*/ pt, center);
 
-            AssertRelation(msg, SpatialRelation.CONTAINS, pt, pt2);
-            AssertRelation(msg, SpatialRelation.DISJOINT, pt, ctx.MakePoint(0, 1));
-            AssertRelation(msg, SpatialRelation.DISJOINT, pt, ctx.MakePoint(1, 0));
-            AssertRelation(msg, SpatialRelation.DISJOINT, pt, ctx.MakePoint(1, 1));
+            AssertRelation(msg, SpatialRelation.Contains, pt, pt2);
+            AssertRelation(msg, SpatialRelation.Disjoint, pt, ctx.MakePoint(0, 1));
+            AssertRelation(msg, SpatialRelation.Disjoint, pt, ctx.MakePoint(1, 0));
+            AssertRelation(msg, SpatialRelation.Disjoint, pt, ctx.MakePoint(1, 1));
 
             pt.Reset(1, 2);
             Assert.Equal(ctx.MakePoint(1, 2), pt);
@@ -149,7 +149,7 @@ namespace Spatial4n.Core.Shape
             //INTERSECTION:
             //Start with some static tests that have shown to cause failures at some point:
             Assert.Equal( /*"getX not getY",*/
-                SpatialRelation.INTERSECTS,
+                SpatialRelation.Intersects,
                 ctx.MakeCircle(107, -81, 147).Relate(ctx.MakeRectangle(92, 121, -89, 74)));
 
             TestCircleIntersect();

--- a/Spatial4n.Tests/shape/TestShapesGeo.cs
+++ b/Spatial4n.Tests/shape/TestShapesGeo.cs
@@ -81,11 +81,11 @@ namespace Spatial4n.Core.Shape
 
             //test some relateXRange
             //    opposite +/- 180
-            Assert.Equal(SpatialRelation.INTERSECTS, ctx.MakeRectangle(170, 180, 0, 0).RelateXRange(-180, -170));
-            Assert.Equal(SpatialRelation.INTERSECTS, ctx.MakeRectangle(-90, -45, 0, 0).RelateXRange(-45, -135));
-            Assert.Equal(SpatialRelation.CONTAINS, ctx.WorldBounds.RelateXRange(-90, -135));
+            Assert.Equal(SpatialRelation.Intersects, ctx.MakeRectangle(170, 180, 0, 0).RelateXRange(-180, -170));
+            Assert.Equal(SpatialRelation.Intersects, ctx.MakeRectangle(-90, -45, 0, 0).RelateXRange(-45, -135));
+            Assert.Equal(SpatialRelation.Contains, ctx.WorldBounds.RelateXRange(-90, -135));
             //point on edge at dateline using opposite +/- 180
-            Assert.Equal(SpatialRelation.CONTAINS, ctx.MakeRectangle(170, 180, 0, 0).Relate(ctx.MakePoint(-180, 0)));
+            Assert.Equal(SpatialRelation.Contains, ctx.MakeRectangle(170, 180, 0, 0).Relate(ctx.MakePoint(-180, 0)));
 
             //test 180 becomes -180 for non-zero width rectangle
             Assert.Equal(ctx.MakeRectangle(-180, -170, 0, 0), ctx.MakeRectangle(180, -170, 0, 0));
@@ -118,7 +118,7 @@ namespace Spatial4n.Core.Shape
                 IRectangle r = RandomRectangle(1);
                 int buf = random.Next(0, 90 + 1);
                 IRectangle br = (IRectangle)r.GetBuffered(buf, ctx);
-                AssertRelation(null, SpatialRelation.CONTAINS, br, r);
+                AssertRelation(null, SpatialRelation.Contains, br, r);
                 if (r.Width + 2 * buf >= 360)
                     CustomAssert.EqualWithDelta(360, br.Width, 0.0);
                 else
@@ -166,50 +166,50 @@ namespace Spatial4n.Core.Shape
             //    assertEquals("dist != xy space", INTERSECTS, c.relate(r, ctx));//once failed here
             //}
 
-            AssertEquals("bad proportion logic", SpatialRelation.INTERSECTS, ctx.MakeCircle(64, -70, 18).Relate(ctx.MakeRectangle(46, 116, -86, -62)));
+            AssertEquals("bad proportion logic", SpatialRelation.Intersects, ctx.MakeCircle(64, -70, 18).Relate(ctx.MakeRectangle(46, 116, -86, -62)));
 
-            AssertEquals("Both touch pole", SpatialRelation.INTERSECTS, ctx.MakeCircle(-90, 30, 60).Relate(ctx.MakeRectangle(-24, -16, 14, 90)));
+            AssertEquals("Both touch pole", SpatialRelation.Intersects, ctx.MakeCircle(-90, 30, 60).Relate(ctx.MakeRectangle(-24, -16, 14, 90)));
 
-            AssertEquals("Spherical cap should contain enclosed band", SpatialRelation.CONTAINS,
+            AssertEquals("Spherical cap should contain enclosed band", SpatialRelation.Contains,
                 ctx.MakeCircle(0, -90, 30).Relate(ctx.MakeRectangle(-180, 180, -90, -80)));
 
-            AssertEquals("touches pole", SpatialRelation.INTERSECTS, ctx.MakeCircle(0, -88, 2).Relate(ctx.MakeRectangle(40, 60, -90, -86)));
+            AssertEquals("touches pole", SpatialRelation.Intersects, ctx.MakeCircle(0, -88, 2).Relate(ctx.MakeRectangle(40, 60, -90, -86)));
 
-            AssertEquals("wrong farthest opp corner", SpatialRelation.INTERSECTS, ctx.MakeCircle(92, 36, 46).Relate(ctx.MakeRectangle(134, 136, 32, 80)));
+            AssertEquals("wrong farthest opp corner", SpatialRelation.Intersects, ctx.MakeCircle(92, 36, 46).Relate(ctx.MakeRectangle(134, 136, 32, 80)));
 
-            AssertEquals("edge rounding issue 2", SpatialRelation.INTERSECTS, ctx.MakeCircle(84, -40, 136).Relate(ctx.MakeRectangle(-150, -80, 34, 84)));
+            AssertEquals("edge rounding issue 2", SpatialRelation.Intersects, ctx.MakeCircle(84, -40, 136).Relate(ctx.MakeRectangle(-150, -80, 34, 84)));
 
-            AssertEquals("edge rounding issue", SpatialRelation.CONTAINS, ctx.MakeCircle(0, 66, 156).Relate(ctx.MakePoint(0, -90)));
+            AssertEquals("edge rounding issue", SpatialRelation.Contains, ctx.MakeCircle(0, 66, 156).Relate(ctx.MakePoint(0, -90)));
 
-            AssertEquals("nudge back circle", SpatialRelation.CONTAINS, ctx.MakeCircle(-150, -90, 122).Relate(ctx.MakeRectangle(0, -132, 32, 32)));
+            AssertEquals("nudge back circle", SpatialRelation.Contains, ctx.MakeCircle(-150, -90, 122).Relate(ctx.MakeRectangle(0, -132, 32, 32)));
 
-            AssertEquals("wrong estimate", SpatialRelation.DISJOINT, ctx.MakeCircle(-166, 59, KmToDeg(5226.2)).Relate(ctx.MakeRectangle(36, 66, 23, 23)));
+            AssertEquals("wrong estimate", SpatialRelation.Disjoint, ctx.MakeCircle(-166, 59, KmToDeg(5226.2)).Relate(ctx.MakeRectangle(36, 66, 23, 23)));
 
-            AssertEquals("bad CONTAINS (dateline)", SpatialRelation.INTERSECTS, ctx.MakeCircle(56, -50, KmToDeg(12231.5)).Relate(ctx.MakeRectangle(108, 26, 39, 48)));
+            AssertEquals("bad CONTAINS (dateline)", SpatialRelation.Intersects, ctx.MakeCircle(56, -50, KmToDeg(12231.5)).Relate(ctx.MakeRectangle(108, 26, 39, 48)));
 
-            AssertEquals("bad CONTAINS (backwrap2)", SpatialRelation.INTERSECTS,
+            AssertEquals("bad CONTAINS (backwrap2)", SpatialRelation.Intersects,
                 ctx.MakeCircle(112, -3, 91).Relate(ctx.MakeRectangle(-163, 29, -38, 10)));
 
-            AssertEquals("bad CONTAINS (r x-wrap)", SpatialRelation.INTERSECTS,
+            AssertEquals("bad CONTAINS (r x-wrap)", SpatialRelation.Intersects,
                 ctx.MakeCircle(-139, 47, 80).Relate(ctx.MakeRectangle(-180, 180, -3, 12)));
 
-            AssertEquals("bad CONTAINS (pwrap)", SpatialRelation.INTERSECTS,
+            AssertEquals("bad CONTAINS (pwrap)", SpatialRelation.Intersects,
                 ctx.MakeCircle(-139, 47, 80).Relate(ctx.MakeRectangle(-180, 179, -3, 12)));
 
-            AssertEquals("no-dist 1", SpatialRelation.WITHIN,
+            AssertEquals("no-dist 1", SpatialRelation.Within,
                 ctx.MakeCircle(135, 21, 0).Relate(ctx.MakeRectangle(-103, -154, -47, 52)));
 
-            AssertEquals("bbox <= >= -90 bug", SpatialRelation.CONTAINS,
+            AssertEquals("bbox <= >= -90 bug", SpatialRelation.Contains,
                 ctx.MakeCircle(-64, -84, 124).Relate(ctx.MakeRectangle(-96, 96, -10, -10)));
 
             //The horizontal axis line of a geo circle doesn't necessarily pass through c's ctr.
-            AssertEquals("c's horiz axis doesn't pass through ctr", SpatialRelation.INTERSECTS,
+            AssertEquals("c's horiz axis doesn't pass through ctr", SpatialRelation.Intersects,
                 ctx.MakeCircle(71, -44, 40).Relate(ctx.MakeRectangle(15, 27, -62, -34)));
 
-            AssertEquals("pole boundary", SpatialRelation.INTERSECTS,
+            AssertEquals("pole boundary", SpatialRelation.Intersects,
                 ctx.MakeCircle(-100, -12, 102).Relate(ctx.MakeRectangle(143, 175, 4, 32)));
 
-            AssertEquals("full circle assert", SpatialRelation.CONTAINS,
+            AssertEquals("full circle assert", SpatialRelation.Contains,
                 ctx.MakeCircle(-64, 32, 180).Relate(ctx.MakeRectangle(47, 47, -14, 90)));
 
             //--Now proceed with systematic testing:

--- a/Spatial4n.Tests/shape/TestShapesGeo.cs
+++ b/Spatial4n.Tests/shape/TestShapesGeo.cs
@@ -58,12 +58,12 @@ namespace Spatial4n.Core.Shape
 
         private static double DegToKm(double deg)
         {
-            return DistanceUtils.Degrees2Dist(deg, DistanceUtils.EARTH_MEAN_RADIUS_KM);
+            return DistanceUtils.Degrees2Dist(deg, DistanceUtils.EarthMeanRadiusKilometers);
         }
 
         private static double KmToDeg(double km)
         {
-            return DistanceUtils.Dist2Degrees(km, DistanceUtils.EARTH_MEAN_RADIUS_KM);
+            return DistanceUtils.Dist2Degrees(km, DistanceUtils.EarthMeanRadiusKilometers);
         }
 
         [Theory]

--- a/Spatial4n.Tests/util/TestGeohashUtils.cs
+++ b/Spatial4n.Tests/util/TestGeohashUtils.cs
@@ -122,7 +122,7 @@ namespace Spatial4n.Core.Util
             Assert.Equal(3, GeohashUtils.LookupHashLenForWidthHeight(999, 5.5));
             Assert.Equal(3, GeohashUtils.LookupHashLenForWidthHeight(11.1, 999));
 
-            Assert.Equal(GeohashUtils.MAX_PRECISION, GeohashUtils.LookupHashLenForWidthHeight(10e-20, 10e-20));
+            Assert.Equal(GeohashUtils.MaxPrecision, GeohashUtils.LookupHashLenForWidthHeight(10e-20, 10e-20));
         }
     }
 }


### PR DESCRIPTION
- Renamed enum and constant values to PascalCase and deprecated the old naming convention
- Marked all obsolete APIs with `EditorBrowsable.Never` so they won't be visible in IDE tools
- Fixed leading whitespace on several files (spaces not tabs)